### PR TITLE
Service account for github runners

### DIFF
--- a/modules/k8s/github-runners/variables.tf
+++ b/modules/k8s/github-runners/variables.tf
@@ -30,3 +30,15 @@ variable "repos" {
   }))
   default = []
 }
+
+variable "enable_service_account" {
+  description = "Enable creation of service account for github runner."
+  type        = bool
+  default     = true
+}
+
+variable "service_account_name" {
+  description = "Name of kuberbets service account for Github runner pod."
+  type        = string
+  default     = "actions-runner"
+}


### PR DESCRIPTION
Adds service with enough access to deploy to kubernetes from the runner. Great for self-hosted runners deploying to the same cluster.