### PR TITLE
Add optional secret to helm module

### DIFF
--- a/modules/k8s/helm-chart/main.tf
+++ b/modules/k8s/helm-chart/main.tf
@@ -32,6 +32,16 @@ locals {
   )
 }
 
+resource "kubernetes_secret" "custom_secret" {
+  count = length(var.secret_data) > 0 ? 1 : 0
+  metadata {
+    name      = var.secret_name
+    namespace = var.namespace
+  }
+  data = var.secret_data
+  type = "Opaque"
+}
+
 resource "helm_release" "k8s" {
   repository = var.helm_repo
   name       = var.name
@@ -45,5 +55,6 @@ resource "helm_release" "k8s" {
 
   depends_on = [
     kubernetes_namespace.namespace,
+    kubernetes_secret.custom_secret
   ]
 }

--- a/modules/k8s/helm-chart/variables.tf
+++ b/modules/k8s/helm-chart/variables.tf
@@ -21,6 +21,18 @@ variable "extra_namespaces" {
   default     = []
 }
 
+variable "secret_name" {
+  description = "The name of the Kubernetes secret"
+  type        = string
+  default     = ""
+}
+
+variable "secret_data" {
+  description = "The data for the Kubernetes secret"
+  type        = map(string)
+  default     = {}
+}
+
 variable "helm_repo" {
   description = "Helm chart repo URL."
   type        = string


### PR DESCRIPTION
Adds ability to create a helm secret that can then be used with the chart. Be sure to pass in the name into helm values as needed. Gives flexiblity to create your own user/pass vs using generated.