### PR TITLE
Module to deploy Talos to Proxmox.

### DIFF
--- a/modules/proxmox/talos-pve/README.md
+++ b/modules/proxmox/talos-pve/README.md
@@ -1,0 +1,103 @@
+# Talos Control Plane VMs (Proxmox)
+
+This module provisions one or more Talos control plane VMs on Proxmox using a pre-built Talos factory ISO. It downloads the ISO into a datastore, uploads optional NoCloud payloads, and creates a VM for each entry in the `instances` map.
+
+## Usage
+
+```hcl
+module "talos_control_plane" {
+  source = "../modules/talos-pve"
+
+  default_vm_specs = {
+    cpu_cores    = 4
+    cpu_sockets  = 1
+    cpu_type     = "host"
+    memory_mb    = 8192
+    disk_size_gb = 50
+    bios_type    = "ovmf"
+  }
+
+  default_proxmox_network = {
+    bridge = "vmbr0"
+  }
+
+  default_tags = ["talos", "control-plane"]
+  default_disk_interface = "virtio0"
+
+  instances = {
+    cp01 = {
+      name         = "talos-cp-01"
+      proxmox_node = "pve1"
+      vm_id        = 1100
+      iso_url      = "https://factory.talos.dev/image/.../nocloud-amd64.iso"
+      additional_disks = [
+        {
+          datastore_id = "ceph-ssd"
+          interface    = "scsi1"
+          size_gb      = 100
+          ssd          = true
+        }
+      ]
+      cloud_init = {
+        datastore_id = "local"
+        user_data    = file("controlplane01.yaml")
+      }
+    }
+    cp02 = {
+      proxmox_node = "pve1"
+      vm_id        = 1101
+      iso_url      = "https://factory.talos.dev/image/.../nocloud-amd64.iso"
+      cloud_init = {
+        datastore_id = "local"
+        user_data    = file("controlplane02.yaml")
+      }
+    }
+  }
+
+  pve_connection = {
+    node         = "pve1"
+    endpoint     = "https://pve1.example.internal:8006"
+    api_user     = "terraform@pam"
+    api_password = var.proxmox_password
+  }
+}
+```
+
+```
+
+To reuse an ISO that was already uploaded (for example, by the control-plane deployment) set `skip_iso_download = true` and provide `existing_iso_file_id` with the file ID you want to attach:
+
+```hcl
+instances = {
+  worker01 = {
+    proxmox_node         = "pve1"
+    vm_id                = 1200
+    skip_iso_download    = true
+    existing_iso_file_id = var.control_plane_iso_file_ids["cp01"]
+    iso_url              = "https://factory.talos.dev/image/.../nocloud-amd64.iso" # unused when skipping download
+    cloud_init = {
+      datastore_id = "local"
+      user_data    = file("worker01.yaml")
+    }
+  }
+}
+```
+
+You can also enforce this behaviour for every instance by setting `default_skip_iso_download = true` and supplying `default_existing_iso_file_id` (individual instances can still override either value).
+
+## Inputs (selected)
+
+- `instances` – Map of control plane nodes to create (name, target node, ISO URL, optional overrides, disk interface, BIOS type, optional reuse of existing ISO file IDs, extra disks, USB pass-through, cloud-init payloads, etc.).
+- `default_skip_iso_download`, `default_existing_iso_file_id` – module-wide defaults for reusing an already-uploaded ISO when per-instance values are omitted.
+- `default_vm_specs`, `default_disk_storage`, `default_disk_interface`, `default_iso_storage`, `default_proxmox_network`, `default_tags`, `default_enable_rng`, `default_description_prefix` – baseline settings applied when an instance omits a value (including `bios_type` when set).
+- `pve_connection` – Proxmox API connection details (node, endpoint, and credentials).
+
+## Outputs
+
+- `vm_ids` – Map of VMIDs keyed by instance name.
+- `vm_names` – Map of VM names keyed by instance name.
+- `iso_file_ids` – Map of ISO file IDs keyed by instance name.
+
+Supply Talos factory ISOs that already contain the desired machine configuration (e.g. generated with Talos Factory). Optional NoCloud payloads can still be uploaded via the `cloud_init` field for additional customization.
+
+When `cloud_init.user_data` is provided, the module patches the YAML so that `machine.network.hostname` defaults to the VM name (unless you already set a hostname in the payload).

--- a/modules/proxmox/talos-pve/main.tf
+++ b/modules/proxmox/talos-pve/main.tf
@@ -1,0 +1,103 @@
+locals {
+  instance_user_data_maps = {
+    for key, inst in var.instances : key => try(yamldecode(try(inst.cloud_init.user_data, "{}")), {})
+  }
+  instance_user_data_decodable = {
+    for key, inst in var.instances : key => can(yamldecode(try(inst.cloud_init.user_data, "")))
+  }
+  instance_user_data_provided = {
+    for key, inst in var.instances : key => inst.cloud_init != null && try(inst.cloud_init.user_data, null) != null
+  }
+}
+
+locals {
+  instances = {
+    for key, inst in var.instances : key => {
+      name = coalesce(try(inst.name, null), key)
+      description = coalesce(
+        try(inst.description, null),
+        format("%s %s", var.default_description_prefix, coalesce(try(inst.name, null), key))
+      )
+      proxmox_node         = inst.proxmox_node
+      vm_id                = try(inst.vm_id, null)
+      iso_storage          = coalesce(try(inst.iso_storage, null), var.default_iso_storage)
+      disk_storage         = coalesce(try(inst.disk_storage, null), var.default_disk_storage)
+      disk_interface       = coalesce(try(inst.disk_interface, null), var.default_disk_interface)
+      skip_iso_download    = coalesce(try(inst.skip_iso_download, null), var.default_skip_iso_download, false)
+      existing_iso_file_id = coalesce(try(inst.existing_iso_file_id, null), var.default_existing_iso_file_id, null)
+      vm_specs             = try(inst.vm_specs, null) != null ? inst.vm_specs : var.default_vm_specs
+      proxmox_network      = merge(var.default_proxmox_network, try(inst.proxmox_network, {}))
+      tags                 = coalesce(try(inst.tags, null), var.default_tags)
+      enable_rng           = coalesce(try(inst.enable_rng, null), var.default_enable_rng)
+      additional_disks     = coalesce(try(inst.additional_disks, null), [])
+      usb_devices          = coalesce(try(inst.usb_devices, null), [])
+      iso_download = coalesce(try(inst.skip_iso_download, null), var.default_skip_iso_download, false) ? null : {
+        datastore_id = coalesce(try(inst.iso_storage, null), var.default_iso_storage)
+        url          = inst.iso_url
+        file_name    = basename(inst.iso_url)
+        overwrite    = true
+      }
+      iso_file_id = coalesce(try(inst.skip_iso_download, null), var.default_skip_iso_download, false) ? coalesce(try(inst.existing_iso_file_id, null), var.default_existing_iso_file_id) : null
+      cloud_init = inst.cloud_init == null ? null : merge(
+        {
+          datastore_id = coalesce(
+            try(inst.cloud_init.datastore_id, null),
+            coalesce(try(inst.iso_storage, null), var.default_iso_storage)
+          )
+          disk_datastore_id = coalesce(
+            try(inst.cloud_init.disk_datastore_id, null),
+            coalesce(try(inst.disk_storage, null), var.default_disk_storage)
+          )
+        },
+        {
+          for k, v in inst.cloud_init : k => (
+            k == "user_data" && local.instance_user_data_provided[key] && local.instance_user_data_decodable[key]
+            ? yamlencode(merge(
+              local.instance_user_data_maps[key],
+              {
+                machine = merge(
+                  try(local.instance_user_data_maps[key].machine, {}),
+                  {
+                    network = merge(
+                      try(local.instance_user_data_maps[key].machine.network, {}),
+                      {
+                        hostname = coalesce(
+                          try(local.instance_user_data_maps[key].machine.network.hostname, null),
+                          replace(replace(coalesce(try(inst.name, null), key), " ", "-"), ".", "-")
+                        )
+                      }
+                    )
+                  }
+                )
+              }
+            ))
+            : v
+          )
+          if !contains(["datastore_id", "disk_datastore_id"], k)
+        }
+      )
+    }
+  }
+}
+
+module "proxmox_vm" {
+  for_each = local.instances
+  source   = "../vm"
+
+  name        = each.value.name
+  description = each.value.description
+  node        = each.value.proxmox_node
+  vm_id       = each.value.vm_id
+
+  vm_specs         = each.value.vm_specs
+  disk_storage     = each.value.disk_storage
+  disk_interface   = each.value.disk_interface
+  iso_download     = each.value.iso_download
+  iso_file_id      = each.value.iso_file_id
+  network          = each.value.proxmox_network
+  tags             = each.value.tags
+  enable_rng       = each.value.enable_rng
+  cloud_init       = each.value.cloud_init
+  additional_disks = each.value.additional_disks
+  usb_devices      = each.value.usb_devices
+}

--- a/modules/proxmox/talos-pve/outputs.tf
+++ b/modules/proxmox/talos-pve/outputs.tf
@@ -1,0 +1,14 @@
+output "vm_ids" {
+  description = "VMIDs assigned to the control plane nodes, keyed by instance name."
+  value       = { for key, mod in module.proxmox_vm : key => mod.vm_id }
+}
+
+output "vm_names" {
+  description = "Names of the control plane VMs, keyed by instance name."
+  value       = { for key, mod in module.proxmox_vm : key => mod.name }
+}
+
+output "iso_file_ids" {
+  description = "File IDs of the Talos ISO attached to each VM, keyed by instance name."
+  value       = { for key, mod in module.proxmox_vm : key => mod.iso_file_id }
+}

--- a/modules/proxmox/talos-pve/variables.tf
+++ b/modules/proxmox/talos-pve/variables.tf
@@ -1,0 +1,171 @@
+variable "instances" {
+  description = "Map of Talos control plane VMs to create."
+  type = map(object({
+    name                 = optional(string)
+    description          = optional(string)
+    proxmox_node         = string
+    vm_id                = optional(number)
+    iso_url              = string
+    iso_storage          = optional(string)
+    disk_storage         = optional(string)
+    disk_interface       = optional(string)
+    skip_iso_download    = optional(bool)
+    existing_iso_file_id = optional(string)
+    vm_specs = optional(object({
+      cpu_cores    = number
+      cpu_sockets  = number
+      cpu_type     = string
+      memory_mb    = number
+      disk_size_gb = number
+      bios_type    = optional(string)
+    }))
+    proxmox_network = optional(object({
+      bridge      = string
+      vlan_id     = optional(number)
+      mac_address = optional(string)
+      model       = optional(string)
+    }))
+    tags       = optional(list(string))
+    enable_rng = optional(bool)
+    additional_disks = optional(list(object({
+      datastore_id = string
+      interface    = string
+      size_gb      = number
+      discard      = optional(string)
+      ssd          = optional(bool)
+      cache        = optional(string)
+      backup       = optional(bool)
+      aio          = optional(string)
+      iothread     = optional(bool)
+      replicate    = optional(bool)
+      serial       = optional(string)
+    })))
+    usb_devices = optional(list(object({
+      host    = optional(string)
+      mapping = optional(string)
+      usb3    = optional(bool)
+    })))
+    cloud_init = optional(object({
+      datastore_id      = optional(string)
+      disk_datastore_id = optional(string)
+      interface         = optional(string)
+      user_data         = optional(string)
+      user_data_name    = optional(string)
+      meta_data         = optional(string)
+      meta_data_name    = optional(string)
+      vendor_data       = optional(string)
+      vendor_data_name  = optional(string)
+    }))
+  }))
+  validation {
+    condition     = length(var.instances) > 0
+    error_message = "Provide at least one control plane VM definition in instances."
+  }
+  validation {
+    condition = alltrue([
+      for inst in var.instances : !(coalesce(try(inst.skip_iso_download, null), var.default_skip_iso_download, false) && coalesce(try(inst.existing_iso_file_id, null), var.default_existing_iso_file_id, null) == null)
+    ])
+    error_message = "When skip_iso_download is true you must provide an existing ISO file ID either per instance or via the module default."
+  }
+}
+
+variable "default_skip_iso_download" {
+  description = "Whether instances should skip downloading the ISO when they do not specify otherwise."
+  type        = bool
+  default     = false
+}
+
+variable "default_existing_iso_file_id" {
+  description = "Existing ISO file ID reused when skipping downloads and no per-instance override is supplied."
+  type        = string
+  default     = null
+}
+
+variable "default_vm_specs" {
+  description = "Default CPU, memory, disk sizing, and optional BIOS type for control plane VMs."
+  type = object({
+    cpu_cores    = number
+    cpu_sockets  = number
+    cpu_type     = string
+    memory_mb    = number
+    disk_size_gb = number
+    bios_type    = optional(string)
+  })
+  default = {
+    cpu_cores    = 4
+    cpu_sockets  = 1
+    cpu_type     = "host"
+    memory_mb    = 4096
+    disk_size_gb = 50
+  }
+}
+
+variable "default_disk_storage" {
+  description = "Default datastore used for VM disks."
+  type        = string
+  default     = "local-lvm"
+}
+
+variable "default_disk_interface" {
+  description = "Default disk interface identifier passed to the VM (e.g. scsi0, virtio0)."
+  type        = string
+  default     = "scsi0"
+}
+
+variable "default_iso_storage" {
+  description = "Default datastore used for the Talos ISO. Must allow `iso` content."
+  type        = string
+  default     = "local"
+}
+
+variable "default_proxmox_network" {
+  description = "Default Proxmox virtual NIC settings."
+  type = object({
+    bridge      = string
+    vlan_id     = optional(number)
+    mac_address = optional(string)
+    model       = optional(string)
+  })
+  default = {
+    bridge = "vmbr0"
+  }
+}
+
+variable "default_tags" {
+  description = "Default list of tags applied to control plane VMs."
+  type        = list(string)
+  default     = []
+}
+
+variable "default_enable_rng" {
+  description = "Whether to expose a RNG device to control plane VMs by default."
+  type        = bool
+  default     = false
+}
+
+variable "default_description_prefix" {
+  description = "Default prefix used when generating VM descriptions."
+  type        = string
+  default     = "Talos control plane"
+}
+
+variable "pve_connection" {
+  description = "Connection info for the target Proxmox environment."
+  type = object({
+    node                 = string
+    api_user             = string
+    api_password         = optional(string)
+    api_token_id         = optional(string)
+    api_token_secret     = optional(string)
+    endpoint             = string
+    tls_insecure         = optional(bool)
+    otp                  = optional(string)
+    ssh_user             = optional(string, "root")
+    ssh_private_key_path = optional(string, "~/.ssh/id_rsa")
+  })
+
+  validation {
+    condition     = trimspace(var.pve_connection.endpoint) != ""
+    error_message = "pve_connection.endpoint must be a non-empty URL."
+  }
+}

--- a/modules/proxmox/talos-pve/versions.tf
+++ b/modules/proxmox/talos-pve/versions.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = ">= 0.63.0"
+    }
+  }
+}
+
+provider "proxmox" {
+  endpoint = trimspace(var.pve_connection.endpoint)
+  insecure = try(var.pve_connection.tls_insecure, true)
+
+  username = var.pve_connection.api_user
+  password = try(var.pve_connection.api_password, null)
+  api_token = (
+    try(var.pve_connection.api_token_id, null) != null &&
+    try(var.pve_connection.api_token_secret, null) != null
+  ) ? format("%s=%s", var.pve_connection.api_token_id, var.pve_connection.api_token_secret) : null
+  otp = try(var.pve_connection.otp, null)
+
+  ssh {
+    username    = try(var.pve_connection.ssh_user, "root")
+    private_key = file(try(var.pve_connection.ssh_private_key_path, "~/.ssh/id_rsa"))
+  }
+}


### PR DESCRIPTION
Uses Proxmox module to deploy Talos nodes. Can be either control plane or worker. Uses cloud-init instead of Talos provider. 