### PR TITLE
Add Proxmox k8s API load balancer module

### DIFF
--- a/modules/proxmox/k8s-api-lb/README.md
+++ b/modules/proxmox/k8s-api-lb/README.md
@@ -1,0 +1,123 @@
+# Proxmox Kubernetes API Load Balancer
+
+This module provisions 2-3 Proxmox LXCs running HAProxy and Keepalived outside the cluster so a Talos or Kubernetes control plane can be exposed through a stable VRRP virtual IP.
+
+## Features
+
+- Uses the `bpg/proxmox` provider with typed inputs.
+- Supports 2 or 3 load balancer nodes.
+- Downloads an LXC template to each target Proxmox node when needed.
+- Renders HAProxy and Keepalived configuration from Terraform templates.
+- Bootstraps packages and configuration through a Proxmox hook script.
+- Installs a container-safe HAProxy systemd unit so the service starts reliably inside LXC.
+- Can optionally expose the Talos API on the same VIP through HAProxy port `50000`.
+
+## Example
+
+```hcl
+module "k8s_api_lb" {
+  source = "git::https://github.com/friedcircuits/terraform-modules.git//modules/proxmox/k8s-api-lb?ref=main"
+
+  name_prefix    = "k8s-api-lb"
+  vip_address    = "192.168.1.42/24"
+  vip_dns_name   = "k8s-api.example.com"
+  vrrp_auth_pass = var.k8s_api_lb_vrrp_auth_pass
+
+  control_plane_backends = [
+    {
+      name = "cp01"
+      ip   = "192.168.1.101"
+      port = 6443
+    },
+    {
+      name = "cp02"
+      ip   = "192.168.1.102"
+      port = 6443
+    },
+    {
+      name = "cp03"
+      ip   = "192.168.1.103"
+      port = 6443
+    }
+  ]
+
+  talos_api = {
+    enabled = true
+  }
+
+  instances = {
+    lb01 = {
+      node_name    = "pve1"
+      vm_id        = 2100
+      ipv4_address = "192.168.1.21/24"
+      gateway      = "192.168.1.1"
+      priority     = 120
+    }
+    lb02 = {
+      node_name    = "pve2"
+      vm_id        = 2101
+      ipv4_address = "192.168.1.22/24"
+      gateway      = "192.168.1.1"
+      priority     = 110
+    }
+  }
+
+  dns = {
+    domain  = "example.com"
+    servers = ["192.168.1.1"]
+  }
+
+  container_template = {
+    url          = "http://download.proxmox.com/images/system/debian-13-standard_13.1-2_amd64.tar.zst"
+    datastore_id = "local"
+    type         = "debian"
+  }
+
+  snippet_datastore_id = "local"
+
+  root_public_keys = [file("~/.ssh/id_ed25519.pub")]
+
+  pve_connection = {
+    endpoint     = "https://pve.example.com:8006"
+    api_user     = "terraform@pam"
+    api_password = var.proxmox_password
+  }
+}
+```
+
+## Important Notes
+
+- `instances` must contain 2 or 3 entries.
+- Set each instance `ipv4_address` and `vip_address` to match the actual network CIDR for the subnet that carries the VIP. For example, use `/23` on a `/23` network and `/24` on a `/24` network.
+- `vrrp_auth_pass` is limited to 8 characters because Keepalived PASS authentication inherits the VRRP protocol limit.
+- `snippet_datastore_id` must point at a Proxmox storage that supports `snippets`.
+- Prefer `root_public_keys` for guest access. `root_password` is supported but should be used only when keys are not practical.
+- By default the containers are privileged because VRRP VIP management is more reliable in that mode.
+- Proxmox API TLS verification is enabled by default. Set `pve_connection.tls_insecure = true` only if your environment requires it.
+- When `container_template.file_id` is not supplied, the module downloads the template to each Proxmox node referenced by `instances`.
+- The first container boot is handled by a Proxmox hook script. Package auto-start is explicitly suppressed during bootstrap so the packaged HAProxy unit does not race the container-safe replacement unit.
+
+## Inputs
+
+- `name_prefix`: Prefix used to generate hostnames and snippet names.
+- `vip_address`: VRRP VIP in CIDR notation.
+- `vip_dns_name`: DNS name that should resolve to the VIP.
+- `vrrp_auth_pass`: Keepalived authentication password.
+- `control_plane_backends`: API backends rendered into HAProxy.
+- `talos_api`: Optional Talos API listener configuration. When enabled without custom backends, it reuses the control-plane backend IPs on port `50000`.
+- `instances`: Map of LXC nodes, including target Proxmox node and static IPv4 settings.
+- `container_template`: Existing LXC template file ID or a URL to download per node.
+- `dns`: Optional DNS search domain and nameservers.
+- `root_public_keys`: Optional SSH public keys installed for the root account inside each container.
+- `root_password`: Optional root password for each container.
+- `pve_connection`: Proxmox endpoint and credentials.
+
+## Outputs
+
+- `vip_address`: Virtual IP address in CIDR notation.
+- `vip_ip`: Virtual IP address without CIDR mask.
+- `vip_dns_name`: DNS name intended to resolve to the VIP.
+- `container_vm_ids`: Proxmox VMIDs keyed by instance name.
+- `container_names`: Container hostnames keyed by instance name.
+- `container_ipv4_addresses`: Configured IPv4 addresses keyed by instance name.
+- `container_ipv4_reported`: IPv4 addresses reported by Proxmox for each container.

--- a/modules/proxmox/k8s-api-lb/locals.tf
+++ b/modules/proxmox/k8s-api-lb/locals.tf
@@ -1,0 +1,145 @@
+locals {
+  ordered_instance_keys = sort(keys(var.instances))
+
+  instance_defaults = {
+    for index, key in local.ordered_instance_keys : key => {
+      generated_name     = format("%s-%s", var.name_prefix, key)
+      priority           = var.vrrp_priority_base - (index * var.vrrp_priority_step)
+      state              = index == 0 ? "MASTER" : "BACKUP"
+      startup_order      = var.default_startup_order + index
+      startup_up_delay   = var.default_startup_up_delay
+      startup_down_delay = var.default_startup_down_delay
+    }
+  }
+
+  instances = {
+    for key, inst in var.instances : key => {
+      name               = coalesce(try(inst.name, null), local.instance_defaults[key].generated_name)
+      description        = coalesce(try(inst.description, null), format("%s %s", var.default_description_prefix, coalesce(try(inst.name, null), local.instance_defaults[key].generated_name)))
+      node_name          = inst.node_name
+      ipv4_address       = inst.ipv4_address
+      ipv4_address_only  = split("/", inst.ipv4_address)[0]
+      gateway            = try(inst.gateway, null)
+      vm_id              = try(inst.vm_id, null)
+      priority           = coalesce(try(inst.priority, null), local.instance_defaults[key].priority)
+      state              = upper(coalesce(try(inst.state, null), local.instance_defaults[key].state))
+      bridge             = coalesce(try(inst.bridge, null), var.default_bridge)
+      vlan_id            = try(inst.vlan_id, null)
+      mac_address        = try(inst.mac_address, null)
+      mtu                = try(inst.mtu, null)
+      firewall           = coalesce(try(inst.firewall, null), false)
+      rate_limit         = try(inst.rate_limit, null)
+      datastore_id       = coalesce(try(inst.datastore_id, null), var.default_datastore_id)
+      disk_size_gb       = coalesce(try(inst.disk_size_gb, null), var.default_disk_size_gb)
+      cpu_cores          = coalesce(try(inst.cpu_cores, null), var.default_cpu_cores)
+      cpu_units          = coalesce(try(inst.cpu_units, null), var.default_cpu_units)
+      cpu_limit          = coalesce(try(inst.cpu_limit, null), var.default_cpu_limit)
+      memory_mb          = coalesce(try(inst.memory_mb, null), var.default_memory_mb)
+      swap_mb            = coalesce(try(inst.swap_mb, null), var.default_swap_mb)
+      tags               = sort(distinct([for tag in concat(var.default_tags, coalesce(try(inst.tags, null), [])) : lower(tag)]))
+      protection         = coalesce(try(inst.protection, null), var.default_protection)
+      startup_order      = coalesce(try(inst.startup_order, null), local.instance_defaults[key].startup_order)
+      startup_up_delay   = coalesce(try(inst.startup_up_delay, null), local.instance_defaults[key].startup_up_delay)
+      startup_down_delay = coalesce(try(inst.startup_down_delay, null), local.instance_defaults[key].startup_down_delay)
+      started            = coalesce(try(inst.started, null), var.default_started)
+      start_on_boot      = coalesce(try(inst.start_on_boot, null), var.default_start_on_boot)
+      unprivileged       = coalesce(try(inst.unprivileged, null), var.default_unprivileged)
+      nesting            = coalesce(try(inst.nesting, null), var.default_nesting)
+      keyctl             = coalesce(try(inst.keyctl, null), var.default_keyctl)
+      sanitized_name     = replace(coalesce(try(inst.name, null), local.instance_defaults[key].generated_name), ".", "-")
+    }
+  }
+
+  target_nodes = toset([for inst in values(local.instances) : inst.node_name])
+
+  template_download_enabled = try(var.container_template.file_id, null) == null
+
+  template_file_ids = {
+    for key, inst in local.instances : key => (
+      local.template_download_enabled
+      ? proxmox_download_file.container_template[inst.node_name].id
+      : var.container_template.file_id
+    )
+  }
+
+  talos_api_enabled       = coalesce(try(var.talos_api.enabled, null), false)
+  talos_api_frontend_port = coalesce(try(var.talos_api.frontend_port, null), 50000)
+  talos_api_backends = local.talos_api_enabled ? (
+    try(var.talos_api.backends, null) != null ? var.talos_api.backends : [
+      for backend in var.control_plane_backends : {
+        name = backend.name
+        ip   = backend.ip
+        port = local.talos_api_frontend_port
+      }
+    ]
+  ) : []
+
+  haproxy_configs = {
+    for key, inst in local.instances : key => templatefile("${path.module}/templates/haproxy.cfg.tftpl", {
+      frontend_port         = var.haproxy_frontend_port
+      balance_algorithm     = var.haproxy_balance_algorithm
+      health_check_interval = var.haproxy_health_check_interval
+      health_check_fall     = var.haproxy_health_check_fall
+      health_check_rise     = var.haproxy_health_check_rise
+      backends              = var.control_plane_backends
+      talos_api_enabled     = local.talos_api_enabled
+      talos_frontend_port   = local.talos_api_frontend_port
+      talos_backends        = local.talos_api_backends
+    })
+  }
+
+  keepalived_configs = {
+    for key, inst in local.instances : key => templatefile("${path.module}/templates/keepalived.conf.tftpl", {
+      state             = inst.state
+      interface         = var.network_interface_name
+      virtual_router_id = var.vrrp_virtual_router_id
+      priority          = inst.priority
+      advert_int        = var.vrrp_advert_int
+      auth_pass         = var.vrrp_auth_pass
+      vip_address       = var.vip_address
+      instance_ip       = inst.ipv4_address_only
+      peers             = [for peer_key, peer in local.instances : peer.ipv4_address_only if peer_key != key]
+      haproxy_service   = var.haproxy_service_name
+    })
+  }
+
+  bootstrap_scripts = {
+    for key, inst in local.instances : key => templatefile("${path.module}/templates/bootstrap.sh.tftpl", {
+      haproxy_service    = var.haproxy_service_name
+      keepalived_service = var.keepalived_service_name
+      haproxy_config     = local.haproxy_configs[key]
+      keepalived_config  = local.keepalived_configs[key]
+    })
+  }
+
+  hook_scripts = {
+    for key, inst in local.instances : key => <<-EOT
+      #!/bin/sh
+      set -eu
+
+      vmid="$1"
+      phase="$2"
+
+      if [ "$phase" != "post-start" ]; then
+        exit 0
+      fi
+
+      attempts=0
+      until pct exec "$vmid" -- sh -lc 'true' >/dev/null 2>&1; do
+        attempts=$((attempts + 1))
+        if [ "$attempts" -ge 30 ]; then
+          echo "container $vmid did not become ready for pct exec" >&2
+          exit 1
+        fi
+        sleep 2
+      done
+
+      pct exec "$vmid" -- sh -lc 'install -d -m 0755 /usr/local/sbin'
+      pct exec "$vmid" -- sh -lc 'printf %s '"'"'${base64encode(local.bootstrap_scripts[key])}'"'"' | base64 -d >/usr/local/sbin/k8s-api-lb-bootstrap.sh
+chmod 0755 /usr/local/sbin/k8s-api-lb-bootstrap.sh
+sh /usr/local/sbin/k8s-api-lb-bootstrap.sh'
+    EOT
+  }
+
+  vip_address_only = split("/", var.vip_address)[0]
+}

--- a/modules/proxmox/k8s-api-lb/main.tf
+++ b/modules/proxmox/k8s-api-lb/main.tf
@@ -1,0 +1,110 @@
+resource "proxmox_download_file" "container_template" {
+  for_each = local.template_download_enabled ? local.target_nodes : toset([])
+
+  content_type       = "vztmpl"
+  datastore_id       = coalesce(try(var.container_template.datastore_id, null), "local")
+  node_name          = each.value
+  url                = var.container_template.url
+  checksum           = try(var.container_template.checksum, null)
+  checksum_algorithm = try(var.container_template.checksum_algorithm, null)
+  overwrite          = coalesce(try(var.container_template.overwrite, null), true)
+}
+
+resource "proxmox_virtual_environment_file" "hook_script" {
+  for_each = local.instances
+
+  content_type = "snippets"
+  datastore_id = var.snippet_datastore_id
+  node_name    = each.value.node_name
+  file_mode    = "0700"
+
+  source_raw {
+    data      = local.hook_scripts[each.key]
+    file_name = format("%s-hook.sh", each.value.sanitized_name)
+  }
+}
+
+resource "proxmox_virtual_environment_container" "this" {
+  for_each = local.instances
+
+  node_name     = each.value.node_name
+  vm_id         = each.value.vm_id
+  description   = each.value.description
+  started       = each.value.started
+  start_on_boot = each.value.start_on_boot
+  protection    = each.value.protection
+  unprivileged  = each.value.unprivileged
+  tags          = each.value.tags
+
+  hook_script_file_id = proxmox_virtual_environment_file.hook_script[each.key].id
+
+  cpu {
+    cores = each.value.cpu_cores
+    units = each.value.cpu_units
+    limit = each.value.cpu_limit
+  }
+
+  memory {
+    dedicated = each.value.memory_mb
+    swap      = each.value.swap_mb
+  }
+
+  disk {
+    datastore_id = each.value.datastore_id
+    size         = each.value.disk_size_gb
+  }
+
+  features {
+    nesting = each.value.nesting
+    keyctl  = each.value.keyctl
+  }
+
+  initialization {
+    hostname = each.value.name
+
+    dynamic "dns" {
+      for_each = var.dns != null ? [var.dns] : []
+      content {
+        domain  = try(dns.value.domain, null)
+        servers = try(dns.value.servers, null)
+      }
+    }
+
+    ip_config {
+      ipv4 {
+        address = each.value.ipv4_address
+        gateway = each.value.gateway
+      }
+    }
+
+    user_account {
+      keys     = var.root_public_keys
+      password = var.root_password
+    }
+  }
+
+  network_interface {
+    name        = var.network_interface_name
+    bridge      = each.value.bridge
+    vlan_id     = each.value.vlan_id
+    mac_address = each.value.mac_address
+    mtu         = each.value.mtu
+    firewall    = each.value.firewall
+    rate_limit  = each.value.rate_limit
+  }
+
+  operating_system {
+    template_file_id = local.template_file_ids[each.key]
+    type             = coalesce(try(var.container_template.type, null), "ubuntu")
+  }
+
+  startup {
+    order      = tostring(each.value.startup_order)
+    up_delay   = tostring(each.value.startup_up_delay)
+    down_delay = tostring(each.value.startup_down_delay)
+  }
+
+  wait_for_ip {
+    ipv4 = true
+  }
+}

--- a/modules/proxmox/k8s-api-lb/outputs.tf
+++ b/modules/proxmox/k8s-api-lb/outputs.tf
@@ -1,0 +1,34 @@
+output "vip_address" {
+  description = "Virtual IP address in CIDR notation served by Keepalived."
+  value       = var.vip_address
+}
+
+output "vip_ip" {
+  description = "Virtual IP address without CIDR mask."
+  value       = local.vip_address_only
+}
+
+output "vip_dns_name" {
+  description = "DNS name intended to resolve to the Kubernetes API VIP."
+  value       = var.vip_dns_name
+}
+
+output "container_vm_ids" {
+  description = "Proxmox VMIDs assigned to the load balancer containers, keyed by instance name."
+  value       = { for key, ct in proxmox_virtual_environment_container.this : key => ct.vm_id }
+}
+
+output "container_names" {
+  description = "Container hostnames keyed by instance name."
+  value       = { for key, inst in local.instances : key => inst.name }
+}
+
+output "container_ipv4_addresses" {
+  description = "Configured IPv4 addresses for the load balancer containers, keyed by instance name."
+  value       = { for key, inst in local.instances : key => inst.ipv4_address }
+}
+
+output "container_ipv4_reported" {
+  description = "IPv4 addresses reported by Proxmox for each container network interface."
+  value       = { for key, ct in proxmox_virtual_environment_container.this : key => ct.ipv4 }
+}

--- a/modules/proxmox/k8s-api-lb/templates/bootstrap.sh.tftpl
+++ b/modules/proxmox/k8s-api-lb/templates/bootstrap.sh.tftpl
@@ -1,0 +1,85 @@
+#!/bin/sh
+set -eu
+
+export DEBIAN_FRONTEND=noninteractive
+
+haproxy_unit="${haproxy_service}.service"
+case "${haproxy_service}" in
+  *.service) haproxy_unit="${haproxy_service}" ;;
+esac
+
+policy_rc_d_path="/usr/sbin/policy-rc.d"
+policy_rc_d_created=0
+
+cleanup() {
+  if [ "$${policy_rc_d_created}" -eq 1 ]; then
+    rm -f "$${policy_rc_d_path}"
+  fi
+}
+
+trap cleanup EXIT
+
+package_installed() {
+  dpkg-query -W -f='$${Status}' "$1" 2>/dev/null | grep -q 'install ok installed'
+}
+
+if ! package_installed haproxy || ! package_installed keepalived; then
+  if [ ! -e "$${policy_rc_d_path}" ]; then
+    cat <<'POLICY_RC_D_EOF' >"$${policy_rc_d_path}"
+#!/bin/sh
+exit 101
+POLICY_RC_D_EOF
+    chmod 0755 "$${policy_rc_d_path}"
+    policy_rc_d_created=1
+  fi
+
+  apt-get update
+  apt-get install -y --no-install-recommends haproxy keepalived
+fi
+
+install -d -m 0755 /etc/haproxy /etc/keepalived
+
+cat <<'HAPROXY_EOF' >/etc/haproxy/haproxy.cfg
+${haproxy_config}
+HAPROXY_EOF
+
+cat <<'KEEPALIVED_EOF' >/etc/keepalived/keepalived.conf
+${keepalived_config}
+KEEPALIVED_EOF
+
+cat <<'HAPROXY_UNIT_EOF' >"/etc/systemd/system/$${haproxy_unit}"
+[Unit]
+Description=HAProxy Load Balancer
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/haproxy -db -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid
+ExecReload=/usr/sbin/haproxy -c -f /etc/haproxy/haproxy.cfg
+Restart=on-failure
+RestartSec=2s
+
+[Install]
+WantedBy=multi-user.target
+HAPROXY_UNIT_EOF
+
+chmod 0644 /etc/haproxy/haproxy.cfg /etc/keepalived/keepalived.conf "/etc/systemd/system/$${haproxy_unit}"
+
+systemctl daemon-reload
+systemctl reset-failed ${haproxy_service} ${keepalived_service} || true
+systemctl enable ${haproxy_service} ${keepalived_service}
+haproxy -c -f /etc/haproxy/haproxy.cfg
+keepalived --config-test --use-file /etc/keepalived/keepalived.conf
+
+if ! systemctl restart ${haproxy_service}; then
+  systemctl --no-pager --full status ${haproxy_service} || true
+  journalctl --no-pager -u ${haproxy_service} -n 50 || true
+  exit 1
+fi
+
+if ! systemctl restart ${keepalived_service}; then
+  systemctl --no-pager --full status ${keepalived_service} || true
+  journalctl --no-pager -u ${keepalived_service} -n 50 || true
+  exit 1
+fi

--- a/modules/proxmox/k8s-api-lb/templates/haproxy.cfg.tftpl
+++ b/modules/proxmox/k8s-api-lb/templates/haproxy.cfg.tftpl
@@ -1,0 +1,36 @@
+global
+    maxconn 2048
+
+defaults
+    mode tcp
+    option dontlognull
+    timeout connect 10s
+    timeout client 1m
+    timeout server 1m
+    retries 3
+
+frontend k8s_api
+    bind *:${frontend_port}
+    default_backend k8s_controlplane
+
+backend k8s_controlplane
+    mode tcp
+    balance ${balance_algorithm}
+    option tcp-check
+%{ for backend in backends ~}
+    server ${replace(backend.name, ".", "-")} ${backend.ip}:${backend.port} check inter ${health_check_interval} fall ${health_check_fall} rise ${health_check_rise}
+%{ endfor ~}
+
+%{ if talos_api_enabled ~}
+frontend talos_api
+    bind *:${talos_frontend_port}
+    default_backend talos_controlplane
+
+backend talos_controlplane
+    mode tcp
+    balance ${balance_algorithm}
+    option tcp-check
+%{ for backend in talos_backends ~}
+    server ${replace(backend.name, ".", "-")}-talos ${backend.ip}:${backend.port} check inter ${health_check_interval} fall ${health_check_fall} rise ${health_check_rise}
+%{ endfor ~}
+%{ endif ~}

--- a/modules/proxmox/k8s-api-lb/templates/keepalived.conf.tftpl
+++ b/modules/proxmox/k8s-api-lb/templates/keepalived.conf.tftpl
@@ -1,0 +1,41 @@
+global_defs {
+    enable_script_security
+    script_user root
+}
+
+vrrp_script chk_haproxy {
+    script "/usr/bin/systemctl is-active --quiet ${haproxy_service}"
+    user root
+    interval 2
+    fall 2
+    rise 2
+}
+
+vrrp_instance VI_1 {
+    state ${state}
+    interface ${interface}
+    virtual_router_id ${virtual_router_id}
+    priority ${priority}
+    advert_int ${advert_int}
+
+    authentication {
+        auth_type PASS
+        auth_pass ${auth_pass}
+    }
+
+    unicast_src_ip ${instance_ip}
+
+    unicast_peer {
+%{ for peer in peers ~}
+        ${peer}
+%{ endfor ~}
+    }
+
+    virtual_ipaddress {
+        ${vip_address}
+    }
+
+    track_script {
+        chk_haproxy
+    }
+}

--- a/modules/proxmox/k8s-api-lb/variables.tf
+++ b/modules/proxmox/k8s-api-lb/variables.tf
@@ -1,0 +1,343 @@
+variable "name_prefix" {
+  description = "Prefix used when generating container hostnames and snippet file names."
+  type        = string
+}
+
+variable "vip_address" {
+  description = "Virtual IP address in CIDR notation advertised by Keepalived. Set it to match the actual network CIDR for the subnet that carries the VIP."
+  type        = string
+}
+
+variable "vip_dns_name" {
+  description = "DNS name that should resolve to the Kubernetes API VIP."
+  type        = string
+}
+
+variable "vrrp_auth_pass" {
+  description = "VRRP authentication password. Keepalived PASS authentication supports up to 8 characters."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(var.vrrp_auth_pass) >= 1 && length(var.vrrp_auth_pass) <= 8
+    error_message = "vrrp_auth_pass must be between 1 and 8 characters for Keepalived PASS authentication."
+  }
+}
+
+variable "control_plane_backends" {
+  description = "Talos or Kubernetes control-plane API endpoints that HAProxy forwards to."
+  type = list(object({
+    name = string
+    ip   = string
+    port = number
+  }))
+
+  validation {
+    condition     = length(var.control_plane_backends) > 0
+    error_message = "Provide at least one control plane backend."
+  }
+}
+
+variable "instances" {
+  description = "Map of load balancer containers to create. Use 2-3 instances for HA, and set each ipv4_address to the real network CIDR for the VIP subnet."
+  type = map(object({
+    node_name          = string
+    ipv4_address       = string
+    gateway            = optional(string)
+    vm_id              = optional(number)
+    name               = optional(string)
+    description        = optional(string)
+    priority           = optional(number)
+    state              = optional(string)
+    bridge             = optional(string)
+    vlan_id            = optional(number)
+    mac_address        = optional(string)
+    mtu                = optional(number)
+    firewall           = optional(bool)
+    rate_limit         = optional(number)
+    datastore_id       = optional(string)
+    disk_size_gb       = optional(number)
+    cpu_cores          = optional(number)
+    cpu_units          = optional(number)
+    cpu_limit          = optional(number)
+    memory_mb          = optional(number)
+    swap_mb            = optional(number)
+    tags               = optional(list(string))
+    protection         = optional(bool)
+    startup_order      = optional(number)
+    startup_up_delay   = optional(number)
+    startup_down_delay = optional(number)
+    started            = optional(bool)
+    start_on_boot      = optional(bool)
+    unprivileged       = optional(bool)
+    nesting            = optional(bool)
+    keyctl             = optional(bool)
+  }))
+
+  validation {
+    condition     = length(var.instances) >= 2 && length(var.instances) <= 3
+    error_message = "Provide between 2 and 3 load balancer instances."
+  }
+}
+
+variable "default_bridge" {
+  description = "Default Proxmox bridge used by container network interfaces."
+  type        = string
+  default     = "vmbr0"
+}
+
+variable "default_datastore_id" {
+  description = "Default datastore for container root filesystems."
+  type        = string
+  default     = "local-lvm"
+}
+
+variable "default_disk_size_gb" {
+  description = "Default root filesystem size in gigabytes."
+  type        = number
+  default     = 8
+}
+
+variable "default_cpu_cores" {
+  description = "Default number of CPU cores per load balancer container."
+  type        = number
+  default     = 2
+}
+
+variable "default_cpu_units" {
+  description = "Default Proxmox CPU shares for each container."
+  type        = number
+  default     = 1024
+}
+
+variable "default_cpu_limit" {
+  description = "Default CPU limit. Set to 0 for no hard cap."
+  type        = number
+  default     = 0
+}
+
+variable "default_memory_mb" {
+  description = "Default dedicated memory per container in megabytes."
+  type        = number
+  default     = 1024
+}
+
+variable "default_swap_mb" {
+  description = "Default swap allocation per container in megabytes."
+  type        = number
+  default     = 512
+}
+
+variable "default_tags" {
+  description = "Default tags applied to all load balancer containers."
+  type        = list(string)
+  default     = ["k8s", "api-lb", "haproxy", "keepalived"]
+}
+
+variable "default_started" {
+  description = "Whether containers should be started after creation by default."
+  type        = bool
+  default     = true
+}
+
+variable "default_start_on_boot" {
+  description = "Whether containers should start automatically when the host boots."
+  type        = bool
+  default     = true
+}
+
+variable "default_unprivileged" {
+  description = "Whether containers should run unprivileged by default. Privileged mode is the safer default for VRRP VIP management."
+  type        = bool
+  default     = false
+}
+
+variable "default_nesting" {
+  description = "Whether container nesting should be enabled by default."
+  type        = bool
+  default     = false
+}
+
+variable "default_keyctl" {
+  description = "Whether keyctl support should be enabled by default."
+  type        = bool
+  default     = true
+}
+
+variable "default_protection" {
+  description = "Whether Proxmox protection should be enabled by default."
+  type        = bool
+  default     = false
+}
+
+variable "default_startup_order" {
+  description = "Base startup order used when instance-specific startup order is omitted."
+  type        = number
+  default     = 50
+}
+
+variable "default_startup_up_delay" {
+  description = "Default startup delay in seconds before the next guest starts."
+  type        = number
+  default     = 10
+}
+
+variable "default_startup_down_delay" {
+  description = "Default shutdown delay in seconds before the next guest stops."
+  type        = number
+  default     = 5
+}
+
+variable "network_interface_name" {
+  description = "Interface name configured inside each container and referenced by Keepalived."
+  type        = string
+  default     = "eth0"
+}
+
+variable "dns" {
+  description = "Optional DNS settings applied during container initialization."
+  type = object({
+    domain  = optional(string)
+    servers = optional(list(string))
+  })
+  default = null
+}
+
+variable "root_public_keys" {
+  description = "SSH public keys installed for the root account inside each container."
+  type        = list(string)
+  default     = []
+}
+
+variable "root_password" {
+  description = "Optional root password for each container. Prefer SSH keys when possible."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "container_template" {
+  description = "Container template reference. Provide either file_id for an existing template or url to download one per target node."
+  type = object({
+    file_id            = optional(string)
+    url                = optional(string)
+    datastore_id       = optional(string)
+    checksum           = optional(string)
+    checksum_algorithm = optional(string)
+    overwrite          = optional(bool)
+    type               = optional(string)
+  })
+
+  validation {
+    condition = (
+      try(var.container_template.file_id, null) != null && try(var.container_template.url, null) == null
+      ) || (
+      try(var.container_template.file_id, null) == null && try(var.container_template.url, null) != null
+    )
+    error_message = "container_template must define exactly one of file_id or url."
+  }
+}
+
+variable "snippet_datastore_id" {
+  description = "Datastore that allows snippet content for hook scripts. Usually a directory-backed storage such as local."
+  type        = string
+  default     = "local"
+}
+
+variable "haproxy_frontend_port" {
+  description = "Frontend TCP port exposed by HAProxy for the Kubernetes API."
+  type        = number
+  default     = 6443
+}
+
+variable "talos_api" {
+  description = "Optional Talos API listener exposed on the same VIP through HAProxy. When backends are omitted, the module reuses control_plane_backends IPs with the Talos frontend port."
+  type = object({
+    enabled       = optional(bool)
+    frontend_port = optional(number)
+    backends = optional(list(object({
+      name = string
+      ip   = string
+      port = number
+    })))
+  })
+  default = {}
+}
+
+variable "haproxy_balance_algorithm" {
+  description = "HAProxy load-balancing algorithm for the Kubernetes API backend."
+  type        = string
+  default     = "roundrobin"
+}
+
+variable "haproxy_health_check_interval" {
+  description = "HAProxy backend health-check interval."
+  type        = string
+  default     = "5s"
+}
+
+variable "haproxy_health_check_fall" {
+  description = "Number of failed health checks before a backend is marked down."
+  type        = number
+  default     = 3
+}
+
+variable "haproxy_health_check_rise" {
+  description = "Number of successful health checks before a backend is marked up."
+  type        = number
+  default     = 2
+}
+
+variable "vrrp_virtual_router_id" {
+  description = "VRRP virtual router identifier shared by all load balancer nodes."
+  type        = number
+  default     = 51
+}
+
+variable "vrrp_advert_int" {
+  description = "VRRP advertisement interval in seconds."
+  type        = number
+  default     = 1
+}
+
+variable "vrrp_priority_base" {
+  description = "Base priority assigned to the first sorted instance when no explicit priority is set."
+  type        = number
+  default     = 120
+}
+
+variable "vrrp_priority_step" {
+  description = "Priority decrement applied to each subsequent sorted instance when explicit priorities are omitted."
+  type        = number
+  default     = 10
+}
+
+variable "keepalived_service_name" {
+  description = "Systemd service name for Keepalived."
+  type        = string
+  default     = "keepalived"
+}
+
+variable "haproxy_service_name" {
+  description = "Systemd service name for HAProxy."
+  type        = string
+  default     = "haproxy"
+}
+
+variable "default_description_prefix" {
+  description = "Default description prefix used when instance descriptions are not explicitly set."
+  type        = string
+  default     = "Kubernetes API load balancer"
+}
+
+variable "pve_connection" {
+  description = "Connection info for the target Proxmox environment."
+  type = object({
+    api_user         = string
+    api_password     = optional(string)
+    api_token_id     = optional(string)
+    api_token_secret = optional(string)
+    endpoint         = string
+    tls_insecure     = optional(bool)
+  })
+}

--- a/modules/proxmox/k8s-api-lb/versions.tf
+++ b/modules/proxmox/k8s-api-lb/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = ">= 0.103.0"
+    }
+  }
+}
+
+provider "proxmox" {
+  endpoint = trimspace(var.pve_connection.endpoint)
+  insecure = try(var.pve_connection.tls_insecure, false)
+
+  username = var.pve_connection.api_user
+  password = try(var.pve_connection.api_password, null)
+  api_token = (
+    try(var.pve_connection.api_token_id, null) != null &&
+    try(var.pve_connection.api_token_secret, null) != null
+  ) ? format("%s=%s", var.pve_connection.api_token_id, var.pve_connection.api_token_secret) : null
+}


### PR DESCRIPTION
## Summary
Add a new `modules/proxmox/k8s-api-lb` module for running a small HAProxy and Keepalived LXC pair or trio in Proxmox to front Kubernetes and Talos control-plane APIs behind a stable VIP.

## Includes
- Proxmox LXC provisioning with typed inputs
- HAProxy and Keepalived config rendering
- Optional Talos API listener on port `50000`
- Bootstrap flow hardened for first-boot service setup
- README, example configuration, and outputs

## Notes
- The module is currently scoped to 2-3 load balancer instances.
- VIP and instance addresses should match the actual network CIDR of the subnet carrying the VIP.