### PR TITLE
Proxmox Disk Passthrough

### DIFF
--- a/modules/proxmox/talos-pve/README.md
+++ b/modules/proxmox/talos-pve/README.md
@@ -63,8 +63,6 @@ module "talos_control_plane" {
 }
 ```
 
-```
-
 To reuse an ISO that was already uploaded (for example, by the control-plane deployment) set `skip_iso_download = true` and provide `existing_iso_file_id` with the file ID you want to attach:
 
 ```hcl
@@ -85,9 +83,34 @@ instances = {
 
 You can also enforce this behaviour for every instance by setting `default_skip_iso_download = true` and supplying `default_existing_iso_file_id` (individual instances can still override either value).
 
+To attach a host block device directly to a VM, use `passthrough_disks` with a stable `/dev/disk/by-id/...` path from the target Proxmox node:
+
+```hcl
+instances = {
+  cp03 = {
+    proxmox_node = "pve3"
+    vm_id        = 1103
+    iso_url      = "https://factory.talos.dev/image/.../nocloud-amd64.iso"
+
+    passthrough_disks = [
+      {
+        interface         = "scsi1"
+        path_in_datastore = "/dev/disk/by-id/ata-ST2000DM008-2FR102_ZFL12345"
+        file_format       = "raw"
+        discard           = "on"
+        ssd               = false
+        iothread          = true
+      }
+    ]
+  }
+}
+```
+
+Use passthrough only for disks physically attached to the same Proxmox node as the VM. Proxmox datastores such as `k8s` are storage abstractions, not device IDs, so you need the underlying host block-device path instead of the datastore name.
+
 ## Inputs (selected)
 
-- `instances` – Map of control plane nodes to create (name, target node, ISO URL, optional overrides, disk interface, BIOS type, optional reuse of existing ISO file IDs, extra disks, USB pass-through, cloud-init payloads, etc.).
+- `instances` – Map of control plane nodes to create (name, target node, ISO URL, optional overrides, disk interface, BIOS type, optional reuse of existing ISO file IDs, extra disks, passthrough disks, USB pass-through, cloud-init payloads, etc.).
 - `default_skip_iso_download`, `default_existing_iso_file_id` – module-wide defaults for reusing an already-uploaded ISO when per-instance values are omitted.
 - `default_vm_specs`, `default_disk_storage`, `default_disk_interface`, `default_iso_storage`, `default_proxmox_network`, `default_tags`, `default_enable_rng`, `default_description_prefix` – baseline settings applied when an instance omits a value (including `bios_type` when set).
 - `pve_connection` – Proxmox API connection details (node, endpoint, and credentials).

--- a/modules/proxmox/talos-pve/main.tf
+++ b/modules/proxmox/talos-pve/main.tf
@@ -45,6 +45,7 @@ locals {
       tags                 = coalesce(try(inst.tags, null), var.default_tags)
       enable_rng           = coalesce(try(inst.enable_rng, null), var.default_enable_rng)
       additional_disks     = coalesce(try(inst.additional_disks, null), [])
+      passthrough_disks    = coalesce(try(inst.passthrough_disks, null), [])
       usb_devices          = coalesce(try(inst.usb_devices, null), [])
       iso_download = local.instance_iso_settings[key].skip ? null : {
         datastore_id = coalesce(try(inst.iso_storage, null), var.default_iso_storage)
@@ -104,15 +105,16 @@ module "proxmox_vm" {
   node        = each.value.proxmox_node
   vm_id       = each.value.vm_id
 
-  vm_specs         = each.value.vm_specs
-  disk_storage     = each.value.disk_storage
-  disk_interface   = each.value.disk_interface
-  iso_download     = each.value.iso_download
-  iso_file_id      = each.value.iso_file_id
-  network          = each.value.proxmox_network
-  tags             = each.value.tags
-  enable_rng       = each.value.enable_rng
-  cloud_init       = each.value.cloud_init
-  additional_disks = each.value.additional_disks
-  usb_devices      = each.value.usb_devices
+  vm_specs          = each.value.vm_specs
+  disk_storage      = each.value.disk_storage
+  disk_interface    = each.value.disk_interface
+  iso_download      = each.value.iso_download
+  iso_file_id       = each.value.iso_file_id
+  network           = each.value.proxmox_network
+  tags              = each.value.tags
+  enable_rng        = each.value.enable_rng
+  cloud_init        = each.value.cloud_init
+  additional_disks  = each.value.additional_disks
+  passthrough_disks = each.value.passthrough_disks
+  usb_devices       = each.value.usb_devices
 }

--- a/modules/proxmox/talos-pve/variables.tf
+++ b/modules/proxmox/talos-pve/variables.tf
@@ -40,6 +40,19 @@ variable "instances" {
       replicate    = optional(bool)
       serial       = optional(string)
     })))
+    passthrough_disks = optional(list(object({
+      interface         = string
+      path_in_datastore = string
+      file_format       = optional(string)
+      discard           = optional(string)
+      ssd               = optional(bool)
+      cache             = optional(string)
+      backup            = optional(bool)
+      aio               = optional(string)
+      iothread          = optional(bool)
+      replicate         = optional(bool)
+      serial            = optional(string)
+    })))
     usb_devices = optional(list(object({
       host    = optional(string)
       mapping = optional(string)

--- a/modules/proxmox/vm/main.tf
+++ b/modules/proxmox/vm/main.tf
@@ -7,6 +7,10 @@ locals {
     checksum_algorithm = null
   }, { for key, value in var.iso_download : key => value if value != null }) : null
   iso_file_id = var.iso_file_id != null ? var.iso_file_id : (local.iso_download_enabled ? proxmox_virtual_environment_download_file.iso[0].id : null)
+  boot_order = var.boot_order != null ? var.boot_order : compact([
+    var.disk_interface,
+    local.iso_file_id != null ? var.iso_interface : null,
+  ])
 
   sanitized_name = replace(var.name, ".", "-")
 }
@@ -79,7 +83,7 @@ resource "proxmox_virtual_environment_vm" "this" {
   stop_on_destroy = var.stop_on_destroy
   scsi_hardware   = var.scsi_hardware
   machine         = var.machine_type
-  boot_order      = var.boot_order
+  boot_order      = local.boot_order
   bios            = try(var.vm_specs.bios_type, null)
 
   agent {

--- a/modules/proxmox/vm/main.tf
+++ b/modules/proxmox/vm/main.tf
@@ -122,6 +122,24 @@ resource "proxmox_virtual_environment_vm" "this" {
     }
   }
 
+  dynamic "disk" {
+    for_each = var.passthrough_disks
+    content {
+      datastore_id      = ""
+      interface         = disk.value.interface
+      path_in_datastore = disk.value.path_in_datastore
+      file_format       = coalesce(try(disk.value.file_format, null), "raw")
+      discard           = coalesce(try(disk.value.discard, null), var.disk_discard)
+      ssd               = coalesce(try(disk.value.ssd, null), var.disk_ssd)
+      cache             = try(disk.value.cache, null)
+      backup            = try(disk.value.backup, null)
+      aio               = try(disk.value.aio, null)
+      iothread          = try(disk.value.iothread, null)
+      replicate         = try(disk.value.replicate, null)
+      serial            = try(disk.value.serial, null)
+    }
+  }
+
   dynamic "cdrom" {
     for_each = local.iso_file_id == null ? [] : [local.iso_file_id]
     content {

--- a/modules/proxmox/vm/variables.tf
+++ b/modules/proxmox/vm/variables.tf
@@ -45,9 +45,9 @@ variable "machine_type" {
 }
 
 variable "boot_order" {
-  description = "Boot order for the VM."
+  description = "Optional explicit boot order for the VM. When omitted, the module boots from the configured primary disk interface first and falls back to the attached ISO if needed."
   type        = list(string)
-  default     = ["ide2", "scsi0"]
+  default     = null
 }
 
 variable "agent_enabled" {

--- a/modules/proxmox/vm/variables.tf
+++ b/modules/proxmox/vm/variables.tf
@@ -109,6 +109,24 @@ variable "additional_disks" {
   default = []
 }
 
+variable "passthrough_disks" {
+  description = "Optional list of host block devices to attach directly to the VM."
+  type = list(object({
+    interface         = string
+    path_in_datastore = string
+    file_format       = optional(string)
+    discard           = optional(string)
+    ssd               = optional(bool)
+    cache             = optional(string)
+    backup            = optional(bool)
+    aio               = optional(string)
+    iothread          = optional(bool)
+    replicate         = optional(bool)
+    serial            = optional(string)
+  }))
+  default = []
+}
+
 variable "iso_file_id" {
   description = "Existing file ID of the ISO to attach. Provide this when skipping the built-in download logic."
   type        = string


### PR DESCRIPTION
* Adds support for passing throung entire disk.
* Fixes boot ordering, which prevents VM from booting from ISO the 2nd time after OS is installed. 