### PR TITLE
Add reusable Proxmox LXC module

### DIFF
--- a/modules/proxmox/README.md
+++ b/modules/proxmox/README.md
@@ -1,6 +1,7 @@
 # Proxmox Related Modules
 
 - [k8s-api-lb](k8s-api-lb/README.md): external API VIP for Talos or Kubernetes control planes
+- [lxc](lxc/README.md): reusable single-container building block for higher-level Proxmox modules
 - [shutdown-controller](shutdown-controller/README.md): LXC-based UPS and staged shutdown coordinator for Ceph, Talos, and Proxmox
 - [talos-pve](talos-pve/README.md): Talos control plane VMs on Proxmox
 - [vm](vm/): generic Proxmox VM building blocks

--- a/modules/proxmox/k8s-api-lb/README.md
+++ b/modules/proxmox/k8s-api-lb/README.md
@@ -2,9 +2,12 @@
 
 This module provisions 2-3 Proxmox LXCs running HAProxy and Keepalived outside the cluster so a Talos or Kubernetes control plane can be exposed through a stable VRRP virtual IP.
 
+Internally it composes the sibling `../lxc` module so the base Proxmox LXC behavior stays aligned with the rest of this repository.
+
 ## Features
 
 - Uses the `bpg/proxmox` provider with typed inputs.
+- Builds on the local `proxmox/lxc` module for the underlying container provisioning.
 - Supports 2 or 3 load balancer nodes.
 - Downloads an LXC template to each target Proxmox node when needed.
 - Renders HAProxy and Keepalived configuration from Terraform templates.
@@ -96,6 +99,7 @@ module "k8s_api_lb" {
 - Proxmox API TLS verification is enabled by default. Set `pve_connection.tls_insecure = true` only if your environment requires it.
 - When `container_template.file_id` is not supplied, the module downloads the template to each Proxmox node referenced by `instances`.
 - The first container boot is handled by a Proxmox hook script. Package auto-start is explicitly suppressed during bootstrap so the packaged HAProxy unit does not race the container-safe replacement unit.
+- This module owns the `proxmox` provider configuration so it can safely iterate the child `lxc` module with `for_each`. Keep that provider configuration at this level or above when calling it from Terragrunt.
 
 ## Inputs
 

--- a/modules/proxmox/k8s-api-lb/locals.tf
+++ b/modules/proxmox/k8s-api-lb/locals.tf
@@ -50,18 +50,6 @@ locals {
     }
   }
 
-  target_nodes = toset([for inst in values(local.instances) : inst.node_name])
-
-  template_download_enabled = try(var.container_template.file_id, null) == null
-
-  template_file_ids = {
-    for key, inst in local.instances : key => (
-      local.template_download_enabled
-      ? proxmox_download_file.container_template[inst.node_name].id
-      : var.container_template.file_id
-    )
-  }
-
   talos_api_enabled       = coalesce(try(var.talos_api.enabled, null), false)
   talos_api_frontend_port = coalesce(try(var.talos_api.frontend_port, null), 50000)
   talos_api_backends = local.talos_api_enabled ? (

--- a/modules/proxmox/k8s-api-lb/main.tf
+++ b/modules/proxmox/k8s-api-lb/main.tf
@@ -1,110 +1,44 @@
-resource "proxmox_download_file" "container_template" {
-  for_each = local.template_download_enabled ? local.target_nodes : toset([])
-
-  content_type       = "vztmpl"
-  datastore_id       = coalesce(try(var.container_template.datastore_id, null), "local")
-  node_name          = each.value
-  url                = var.container_template.url
-  checksum           = try(var.container_template.checksum, null)
-  checksum_algorithm = try(var.container_template.checksum_algorithm, null)
-  overwrite          = coalesce(try(var.container_template.overwrite, null), true)
-}
-
-resource "proxmox_virtual_environment_file" "hook_script" {
+module "lxc" {
   for_each = local.instances
 
-  content_type = "snippets"
-  datastore_id = var.snippet_datastore_id
-  node_name    = each.value.node_name
-  file_mode    = "0700"
+  source = "../lxc"
 
-  source_raw {
-    data      = local.hook_scripts[each.key]
-    file_name = format("%s-hook.sh", each.value.sanitized_name)
-  }
-}
-
-resource "proxmox_virtual_environment_container" "this" {
-  for_each = local.instances
-
-  node_name     = each.value.node_name
-  vm_id         = each.value.vm_id
-  description   = each.value.description
-  started       = each.value.started
-  start_on_boot = each.value.start_on_boot
-  protection    = each.value.protection
-  unprivileged  = each.value.unprivileged
-  tags          = each.value.tags
-
-  hook_script_file_id = proxmox_virtual_environment_file.hook_script[each.key].id
-
-  cpu {
-    cores = each.value.cpu_cores
-    units = each.value.cpu_units
-    limit = each.value.cpu_limit
-  }
-
-  memory {
-    dedicated = each.value.memory_mb
-    swap      = each.value.swap_mb
-  }
-
-  disk {
-    datastore_id = each.value.datastore_id
-    size         = each.value.disk_size_gb
-  }
-
-  features {
-    nesting = each.value.nesting
-    keyctl  = each.value.keyctl
-  }
-
-  initialization {
-    hostname = each.value.name
-
-    dynamic "dns" {
-      for_each = var.dns != null ? [var.dns] : []
-      content {
-        domain  = try(dns.value.domain, null)
-        servers = try(dns.value.servers, null)
-      }
-    }
-
-    ip_config {
-      ipv4 {
-        address = each.value.ipv4_address
-        gateway = each.value.gateway
-      }
-    }
-
-    user_account {
-      keys     = var.root_public_keys
-      password = var.root_password
-    }
-  }
-
-  network_interface {
-    name        = var.network_interface_name
-    bridge      = each.value.bridge
-    vlan_id     = each.value.vlan_id
-    mac_address = each.value.mac_address
-    mtu         = each.value.mtu
-    firewall    = each.value.firewall
-    rate_limit  = each.value.rate_limit
-  }
-
-  operating_system {
-    template_file_id = local.template_file_ids[each.key]
-    type             = coalesce(try(var.container_template.type, null), "ubuntu")
-  }
-
-  startup {
-    order      = tostring(each.value.startup_order)
-    up_delay   = tostring(each.value.startup_up_delay)
-    down_delay = tostring(each.value.startup_down_delay)
-  }
-
-  wait_for_ip {
-    ipv4 = true
-  }
+  name                   = each.value.name
+  node_name              = each.value.node_name
+  ipv4_address           = each.value.ipv4_address
+  gateway                = each.value.gateway
+  vm_id                  = each.value.vm_id
+  description            = each.value.description
+  bridge                 = each.value.bridge
+  vlan_id                = each.value.vlan_id
+  mac_address            = each.value.mac_address
+  mtu                    = each.value.mtu
+  firewall               = each.value.firewall
+  rate_limit             = each.value.rate_limit
+  datastore_id           = each.value.datastore_id
+  disk_size_gb           = each.value.disk_size_gb
+  cpu_cores              = each.value.cpu_cores
+  cpu_units              = each.value.cpu_units
+  cpu_limit              = each.value.cpu_limit
+  memory_mb              = each.value.memory_mb
+  swap_mb                = each.value.swap_mb
+  tags                   = each.value.tags
+  protection             = each.value.protection
+  startup_order          = each.value.startup_order
+  startup_up_delay       = each.value.startup_up_delay
+  startup_down_delay     = each.value.startup_down_delay
+  started                = each.value.started
+  start_on_boot          = each.value.start_on_boot
+  unprivileged           = each.value.unprivileged
+  nesting                = each.value.nesting
+  keyctl                 = each.value.keyctl
+  network_interface_name = var.network_interface_name
+  dns                    = var.dns
+  root_public_keys       = var.root_public_keys
+  root_password          = var.root_password
+  container_template     = var.container_template
+  snippet_datastore_id   = var.snippet_datastore_id
+  hook_script_content    = local.hook_scripts[each.key]
+  hook_script_file_name  = format("%s-hook.sh", each.value.sanitized_name)
+  pve_connection         = var.pve_connection
 }

--- a/modules/proxmox/k8s-api-lb/outputs.tf
+++ b/modules/proxmox/k8s-api-lb/outputs.tf
@@ -15,7 +15,7 @@ output "vip_dns_name" {
 
 output "container_vm_ids" {
   description = "Proxmox VMIDs assigned to the load balancer containers, keyed by instance name."
-  value       = { for key, ct in proxmox_virtual_environment_container.this : key => ct.vm_id }
+  value       = { for key, inst in module.lxc : key => inst.container_vm_id }
 }
 
 output "container_names" {
@@ -30,5 +30,5 @@ output "container_ipv4_addresses" {
 
 output "container_ipv4_reported" {
   description = "IPv4 addresses reported by Proxmox for each container network interface."
-  value       = { for key, ct in proxmox_virtual_environment_container.this : key => ct.ipv4 }
+  value       = { for key, inst in module.lxc : key => inst.container_ipv4_reported }
 }

--- a/modules/proxmox/lxc/README.md
+++ b/modules/proxmox/lxc/README.md
@@ -1,0 +1,97 @@
+# Proxmox LXC
+
+This module provisions a single Proxmox LXC container using the `bpg/proxmox` provider.
+
+It is intentionally narrow and infrastructure-focused:
+
+- create one container
+- optionally download a container template on the target node
+- optionally upload and attach a hook script snippet
+- configure CPU, memory, disk, networking, startup, and basic guest initialization
+
+This module is intended to be used directly for simple containers or wrapped by higher-level modules such as load balancers or controllers.
+
+For multiple containers, prefer `for_each` on the calling module rather than baking multi-instance behavior into this module.
+
+## Provider Ownership
+
+This module intentionally does not define its own `provider "proxmox"` block.
+
+That is a Terraform limitation rather than a Proxmox-specific requirement: child modules that define their own provider configuration become legacy modules, and callers can no longer use `for_each`, `count`, or `depends_on` on them.
+
+In practice, that means the root module, or the Terragrunt-driven module at the top, should own the Proxmox provider configuration and pass normal inputs into this module. That keeps `lxc` reusable both for direct single-container use and for higher-level modules such as `k8s-api-lb`.
+
+## Usage
+
+```hcl
+module "lxc" {
+  source = "git::https://github.com/friedcircuits/terraform-modules.git//modules/proxmox/lxc?ref=v0.1.0"
+
+  name         = "example-lxc"
+  node_name    = "pve1"
+  vm_id        = 1300
+  ipv4_address = "dhcp"
+
+  container_template = {
+    file_id = "local:vztmpl/debian-13-standard_13.1-2_amd64.tar.zst"
+    type    = "debian"
+  }
+
+  root_public_keys = [file("~/.ssh/id_ed25519.pub")]
+  tags             = ["example", "lxc"]
+
+  pve_connection = {
+    endpoint     = "https://pve.example.com:8006"
+    api_user     = "terraform@pam"
+    api_password = var.proxmox_password
+  }
+}
+```
+
+## Multiple Containers
+
+Use `for_each` in the caller when you need multiple containers:
+
+```hcl
+module "lxc" {
+  for_each = {
+    lb1 = {
+      node_name    = "pve1"
+      vm_id        = 1401
+      ipv4_address = "192.168.1.41/24"
+    }
+    lb2 = {
+      node_name    = "pve2"
+      vm_id        = 1402
+      ipv4_address = "192.168.1.42/24"
+    }
+  }
+
+  source = "../modules/proxmox/lxc"
+
+  name         = "api-lb-${each.key}"
+  node_name    = each.value.node_name
+  vm_id        = each.value.vm_id
+  ipv4_address = each.value.ipv4_address
+
+  container_template = {
+    file_id = "local:vztmpl/debian-13-standard_13.1-2_amd64.tar.zst"
+    type    = "debian"
+  }
+
+  pve_connection = var.pve_connection
+}
+```
+
+## Hook Scripts
+
+If `hook_script_content` is provided, the module uploads it as a Proxmox snippet and attaches it to the container.
+
+This is useful for higher-level modules that render a bootstrap or post-start script outside the base LXC module.
+
+## Notes
+
+- Hook scripts require snippet-capable storage such as `local`.
+- The Proxmox environment must allow the provider to manage snippet files on the target node.
+- The module defaults to a single container by design; composition is preferred over a built-in instances map.
+- Configure the `proxmox` provider in the caller, not inside this module, especially when using Terragrunt or wrapping this module from another module.

--- a/modules/proxmox/lxc/locals.tf
+++ b/modules/proxmox/lxc/locals.tf
@@ -1,0 +1,16 @@
+locals {
+  description = coalesce(
+    var.description,
+    format("LXC %s", var.name)
+  )
+
+  template_download_enabled = try(var.container_template.file_id, null) == null
+  template_file_id          = local.template_download_enabled ? proxmox_download_file.container_template[0].id : var.container_template.file_id
+
+  hook_script_file_name = coalesce(
+    var.hook_script_file_name,
+    format("%s-hook.sh", replace(var.name, ".", "-"))
+  )
+
+  hook_script_file_id = var.hook_script_content != null ? proxmox_virtual_environment_file.hook_script[0].id : null
+}

--- a/modules/proxmox/lxc/main.tf
+++ b/modules/proxmox/lxc/main.tf
@@ -1,0 +1,108 @@
+resource "proxmox_download_file" "container_template" {
+  count = local.template_download_enabled ? 1 : 0
+
+  content_type       = "vztmpl"
+  datastore_id       = coalesce(try(var.container_template.datastore_id, null), "local")
+  node_name          = var.node_name
+  url                = var.container_template.url
+  checksum           = try(var.container_template.checksum, null)
+  checksum_algorithm = try(var.container_template.checksum_algorithm, null)
+  overwrite          = coalesce(try(var.container_template.overwrite, null), true)
+}
+
+resource "proxmox_virtual_environment_file" "hook_script" {
+  count = var.hook_script_content != null ? 1 : 0
+
+  content_type = "snippets"
+  datastore_id = var.snippet_datastore_id
+  node_name    = var.node_name
+  file_mode    = "0700"
+
+  source_raw {
+    data      = var.hook_script_content
+    file_name = local.hook_script_file_name
+  }
+}
+
+resource "proxmox_virtual_environment_container" "this" {
+  node_name     = var.node_name
+  vm_id         = var.vm_id
+  description   = local.description
+  started       = var.started
+  start_on_boot = var.start_on_boot
+  protection    = var.protection
+  unprivileged  = var.unprivileged
+  tags          = sort(distinct([for tag in var.tags : lower(tag)]))
+
+  hook_script_file_id = local.hook_script_file_id
+
+  cpu {
+    cores = var.cpu_cores
+    units = var.cpu_units
+    limit = var.cpu_limit
+  }
+
+  memory {
+    dedicated = var.memory_mb
+    swap      = var.swap_mb
+  }
+
+  disk {
+    datastore_id = var.datastore_id
+    size         = var.disk_size_gb
+  }
+
+  features {
+    nesting = var.nesting
+    keyctl  = var.keyctl
+  }
+
+  initialization {
+    hostname = var.name
+
+    dynamic "dns" {
+      for_each = var.dns != null ? [var.dns] : []
+      content {
+        domain  = try(dns.value.domain, null)
+        servers = try(dns.value.servers, null)
+      }
+    }
+
+    ip_config {
+      ipv4 {
+        address = var.ipv4_address
+        gateway = var.gateway
+      }
+    }
+
+    user_account {
+      keys     = var.root_public_keys
+      password = var.root_password
+    }
+  }
+
+  network_interface {
+    name        = var.network_interface_name
+    bridge      = var.bridge
+    vlan_id     = var.vlan_id
+    mac_address = var.mac_address
+    mtu         = var.mtu
+    firewall    = var.firewall
+    rate_limit  = var.rate_limit
+  }
+
+  operating_system {
+    template_file_id = local.template_file_id
+    type             = coalesce(try(var.container_template.type, null), "debian")
+  }
+
+  startup {
+    order      = tostring(var.startup_order)
+    up_delay   = tostring(var.startup_up_delay)
+    down_delay = tostring(var.startup_down_delay)
+  }
+
+  wait_for_ip {
+    ipv4 = true
+  }
+}

--- a/modules/proxmox/lxc/outputs.tf
+++ b/modules/proxmox/lxc/outputs.tf
@@ -1,0 +1,24 @@
+output "container_vm_id" {
+  description = "Proxmox VMID assigned to the container."
+  value       = proxmox_virtual_environment_container.this.vm_id
+}
+
+output "container_name" {
+  description = "Hostname assigned to the container."
+  value       = var.name
+}
+
+output "container_ipv4_address" {
+  description = "Configured IPv4 address for the container."
+  value       = var.ipv4_address
+}
+
+output "container_ipv4_reported" {
+  description = "IPv4 addresses reported by Proxmox for the container."
+  value       = proxmox_virtual_environment_container.this.ipv4
+}
+
+output "hook_script_file_id" {
+  description = "Proxmox snippet file ID for the uploaded hook script, or null when no hook script is configured."
+  value       = local.hook_script_file_id
+}

--- a/modules/proxmox/lxc/outputs.tf
+++ b/modules/proxmox/lxc/outputs.tf
@@ -21,4 +21,5 @@ output "container_ipv4_reported" {
 output "hook_script_file_id" {
   description = "Proxmox snippet file ID for the uploaded hook script, or null when no hook script is configured."
   value       = local.hook_script_file_id
+  sensitive   = true
 }

--- a/modules/proxmox/lxc/variables.tf
+++ b/modules/proxmox/lxc/variables.tf
@@ -1,0 +1,252 @@
+variable "name" {
+  description = "Hostname assigned to the container."
+  type        = string
+}
+
+variable "node_name" {
+  description = "Proxmox node that hosts the container."
+  type        = string
+}
+
+variable "ipv4_address" {
+  description = "IPv4 address for the container. Use `dhcp` for DHCP or provide a static address in CIDR notation."
+  type        = string
+  default     = "dhcp"
+}
+
+variable "gateway" {
+  description = "Optional IPv4 gateway for the container."
+  type        = string
+  default     = null
+}
+
+variable "vm_id" {
+  description = "Optional static Proxmox VMID for the container."
+  type        = number
+  default     = null
+}
+
+variable "description" {
+  description = "Optional description shown in the Proxmox UI."
+  type        = string
+  default     = null
+}
+
+variable "bridge" {
+  description = "Proxmox bridge attached to the container."
+  type        = string
+  default     = "vmbr0"
+}
+
+variable "vlan_id" {
+  description = "Optional VLAN tag for the container NIC."
+  type        = number
+  default     = null
+}
+
+variable "mac_address" {
+  description = "Optional MAC address for the container NIC."
+  type        = string
+  default     = null
+}
+
+variable "mtu" {
+  description = "Optional MTU for the container NIC."
+  type        = number
+  default     = null
+}
+
+variable "firewall" {
+  description = "Whether to enable the Proxmox firewall flag on the container NIC."
+  type        = bool
+  default     = false
+}
+
+variable "rate_limit" {
+  description = "Optional egress rate limit for the container NIC in MiB/s."
+  type        = number
+  default     = null
+}
+
+variable "datastore_id" {
+  description = "Datastore used for the container root filesystem."
+  type        = string
+  default     = "local-lvm"
+}
+
+variable "disk_size_gb" {
+  description = "Root filesystem size in gigabytes."
+  type        = number
+  default     = 8
+}
+
+variable "cpu_cores" {
+  description = "Number of CPU cores assigned to the container."
+  type        = number
+  default     = 2
+}
+
+variable "cpu_units" {
+  description = "Proxmox CPU shares for the container."
+  type        = number
+  default     = 1024
+}
+
+variable "cpu_limit" {
+  description = "CPU limit for the container. Set to 0 for no hard cap."
+  type        = number
+  default     = 0
+}
+
+variable "memory_mb" {
+  description = "Dedicated memory for the container in megabytes."
+  type        = number
+  default     = 1024
+}
+
+variable "swap_mb" {
+  description = "Swap allocation for the container in megabytes."
+  type        = number
+  default     = 512
+}
+
+variable "tags" {
+  description = "Tags applied to the container."
+  type        = list(string)
+  default     = []
+}
+
+variable "protection" {
+  description = "Whether Proxmox protection should be enabled for the container."
+  type        = bool
+  default     = false
+}
+
+variable "startup_order" {
+  description = "Proxmox startup order for the container."
+  type        = number
+  default     = 50
+}
+
+variable "startup_up_delay" {
+  description = "Delay in seconds before the next guest starts after this container."
+  type        = number
+  default     = 10
+}
+
+variable "startup_down_delay" {
+  description = "Delay in seconds before the next guest stops after this container."
+  type        = number
+  default     = 5
+}
+
+variable "started" {
+  description = "Whether the container should be started after creation."
+  type        = bool
+  default     = true
+}
+
+variable "start_on_boot" {
+  description = "Whether the container should start automatically when the host boots."
+  type        = bool
+  default     = true
+}
+
+variable "unprivileged" {
+  description = "Whether the container should run unprivileged."
+  type        = bool
+  default     = false
+}
+
+variable "nesting" {
+  description = "Whether container nesting should be enabled."
+  type        = bool
+  default     = false
+}
+
+variable "keyctl" {
+  description = "Whether keyctl support should be enabled inside the container."
+  type        = bool
+  default     = true
+}
+
+variable "network_interface_name" {
+  description = "Interface name configured inside the container."
+  type        = string
+  default     = "eth0"
+}
+
+variable "dns" {
+  description = "Optional DNS settings applied during container initialization."
+  type = object({
+    domain  = optional(string)
+    servers = optional(list(string))
+  })
+  default = null
+}
+
+variable "root_public_keys" {
+  description = "SSH public keys installed for the root account inside the container."
+  type        = list(string)
+  default     = []
+}
+
+variable "root_password" {
+  description = "Optional root password for the container. Prefer SSH keys when possible."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "container_template" {
+  description = "Container template reference. Provide either file_id for an existing template or url to download on the target node."
+  type = object({
+    file_id            = optional(string)
+    url                = optional(string)
+    datastore_id       = optional(string)
+    checksum           = optional(string)
+    checksum_algorithm = optional(string)
+    overwrite          = optional(bool)
+    type               = optional(string)
+  })
+
+  validation {
+    condition = (
+      try(var.container_template.file_id, null) != null && try(var.container_template.url, null) == null
+      ) || (
+      try(var.container_template.file_id, null) == null && try(var.container_template.url, null) != null
+    )
+    error_message = "container_template must define exactly one of file_id or url."
+  }
+}
+
+variable "snippet_datastore_id" {
+  description = "Datastore that allows snippet content for hook scripts. Usually a directory-backed storage such as local."
+  type        = string
+  default     = "local"
+}
+
+variable "hook_script_content" {
+  description = "Optional hook script content uploaded as a Proxmox snippet and attached to the container."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "hook_script_file_name" {
+  description = "Optional snippet file name used when hook_script_content is provided. Defaults to <name>-hook.sh."
+  type        = string
+  default     = null
+}
+
+variable "pve_connection" {
+  description = "Connection info for the target Proxmox environment used by Terraform itself."
+  type = object({
+    api_user         = string
+    api_password     = optional(string)
+    api_token_id     = optional(string)
+    api_token_secret = optional(string)
+    endpoint         = string
+    tls_insecure     = optional(bool)
+  })
+}

--- a/modules/proxmox/lxc/versions.tf
+++ b/modules/proxmox/lxc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = ">= 0.103.0"
+    }
+  }
+}

--- a/modules/proxmox/shutdown-controller/README.md
+++ b/modules/proxmox/shutdown-controller/README.md
@@ -4,12 +4,15 @@ This module deploys a small Proxmox LXC that coordinates graceful shutdown steps
 
 It is designed to run outside the Kubernetes cluster it protects, so it can keep operating while the cluster is degraded or shutting down.
 
+Internally it composes the sibling `../lxc` module so the base Proxmox LXC behavior stays aligned with the rest of this repository.
+
 The container is bootstrapped through a Proxmox hook script and prepared with:
 
 - `kubectl` for Kubernetes and Ceph toolbox access
 - `talosctl` for graceful shutdown of Talos nodes
 - `mosquitto_pub` via `mosquitto-clients` for optional MQTT status and event publishing
 - `nut-client` for UPS status polling against an existing NUT server
+- the local `proxmox/lxc` module for the underlying container provisioning
 - optional kubeconfig and talosconfig files
 - an environment file with Ceph, NUT, Talos, Linux, and Proxmox targets
 - a built-in staged controller script with an optional override and matching systemd services
@@ -126,6 +129,7 @@ module "shutdown_controller" {
 - `LINUX_SHUTDOWN_MIN_RUNTIME_SECONDS` lets you place generic Linux shutdown before or after Talos and Proxmox actions depending on what you want to keep alive longest during an outage.
 - The module also installs a one-shot `shutdown-controller-recovery.service` by default. It runs on LXC boot, waits for line power and healthy Ceph, then unsets `noout` safely.
 - Omit `pve_api` entirely if the controller does not need to make Proxmox API calls from inside the container.
+- This module owns the `proxmox` provider configuration so it can safely compose the child `lxc` module. Keep that provider configuration at this level or above when calling it from Terragrunt.
 
 ## Recovery
 

--- a/modules/proxmox/shutdown-controller/locals.tf
+++ b/modules/proxmox/shutdown-controller/locals.tf
@@ -5,9 +5,6 @@ locals {
     format("Shutdown controller %s", var.name)
   )
 
-  template_download_enabled = try(var.container_template.file_id, null) == null
-  template_file_id          = local.template_download_enabled ? proxmox_download_file.container_template[var.node_name].id : var.container_template.file_id
-
   controller_script_content = coalesce(var.controller_script, file("${path.module}/templates/controller.sh.tftpl"))
   recovery_script_content   = file("${path.module}/templates/recovery.sh.tftpl")
 

--- a/modules/proxmox/shutdown-controller/main.tf
+++ b/modules/proxmox/shutdown-controller/main.tf
@@ -1,13 +1,3 @@
-moved {
-  from = proxmox_virtual_environment_container.this
-  to   = module.lxc.proxmox_virtual_environment_container.this
-}
-
-moved {
-  from = proxmox_virtual_environment_file.hook_script
-  to   = module.lxc.proxmox_virtual_environment_file.hook_script[0]
-}
-
 module "lxc" {
   source = "../lxc"
 

--- a/modules/proxmox/shutdown-controller/main.tf
+++ b/modules/proxmox/shutdown-controller/main.tf
@@ -1,106 +1,52 @@
-resource "proxmox_download_file" "container_template" {
-  for_each = local.template_download_enabled ? toset([var.node_name]) : toset([])
-
-  content_type       = "vztmpl"
-  datastore_id       = coalesce(try(var.container_template.datastore_id, null), "local")
-  node_name          = each.value
-  url                = var.container_template.url
-  checksum           = try(var.container_template.checksum, null)
-  checksum_algorithm = try(var.container_template.checksum_algorithm, null)
-  overwrite          = coalesce(try(var.container_template.overwrite, null), true)
+moved {
+  from = proxmox_virtual_environment_container.this
+  to   = module.lxc.proxmox_virtual_environment_container.this
 }
 
-resource "proxmox_virtual_environment_file" "hook_script" {
-  content_type = "snippets"
-  datastore_id = var.snippet_datastore_id
-  node_name    = var.node_name
-  file_mode    = "0700"
-
-  source_raw {
-    data      = local.hook_script
-    file_name = format("%s-hook.sh", replace(var.name, ".", "-"))
-  }
+moved {
+  from = proxmox_virtual_environment_file.hook_script
+  to   = module.lxc.proxmox_virtual_environment_file.hook_script[0]
 }
 
-resource "proxmox_virtual_environment_container" "this" {
-  node_name     = var.node_name
-  vm_id         = var.vm_id
-  description   = local.description
-  started       = var.started
-  start_on_boot = var.start_on_boot
-  protection    = var.protection
-  unprivileged  = var.unprivileged
-  tags          = sort(distinct([for tag in var.tags : lower(tag)]))
+module "lxc" {
+  source = "../lxc"
 
-  hook_script_file_id = proxmox_virtual_environment_file.hook_script.id
-
-  cpu {
-    cores = var.cpu_cores
-    units = var.cpu_units
-    limit = var.cpu_limit
-  }
-
-  memory {
-    dedicated = var.memory_mb
-    swap      = var.swap_mb
-  }
-
-  disk {
-    datastore_id = var.datastore_id
-    size         = var.disk_size_gb
-  }
-
-  features {
-    nesting = var.nesting
-    keyctl  = var.keyctl
-  }
-
-  initialization {
-    hostname = local.container_name
-
-    dynamic "dns" {
-      for_each = var.dns != null ? [var.dns] : []
-      content {
-        domain  = try(dns.value.domain, null)
-        servers = try(dns.value.servers, null)
-      }
-    }
-
-    ip_config {
-      ipv4 {
-        address = var.ipv4_address
-        gateway = var.gateway
-      }
-    }
-
-    user_account {
-      keys     = var.root_public_keys
-      password = var.root_password
-    }
-  }
-
-  network_interface {
-    name        = var.network_interface_name
-    bridge      = var.bridge
-    vlan_id     = var.vlan_id
-    mac_address = var.mac_address
-    mtu         = var.mtu
-    firewall    = var.firewall
-    rate_limit  = var.rate_limit
-  }
-
-  operating_system {
-    template_file_id = local.template_file_id
-    type             = coalesce(try(var.container_template.type, null), "debian")
-  }
-
-  startup {
-    order      = tostring(var.startup_order)
-    up_delay   = tostring(var.startup_up_delay)
-    down_delay = tostring(var.startup_down_delay)
-  }
-
-  wait_for_ip {
-    ipv4 = true
-  }
+  name                   = local.container_name
+  node_name              = var.node_name
+  ipv4_address           = var.ipv4_address
+  gateway                = var.gateway
+  vm_id                  = var.vm_id
+  description            = local.description
+  bridge                 = var.bridge
+  vlan_id                = var.vlan_id
+  mac_address            = var.mac_address
+  mtu                    = var.mtu
+  firewall               = var.firewall
+  rate_limit             = var.rate_limit
+  datastore_id           = var.datastore_id
+  disk_size_gb           = var.disk_size_gb
+  cpu_cores              = var.cpu_cores
+  cpu_units              = var.cpu_units
+  cpu_limit              = var.cpu_limit
+  memory_mb              = var.memory_mb
+  swap_mb                = var.swap_mb
+  tags                   = var.tags
+  protection             = var.protection
+  startup_order          = var.startup_order
+  startup_up_delay       = var.startup_up_delay
+  startup_down_delay     = var.startup_down_delay
+  started                = var.started
+  start_on_boot          = var.start_on_boot
+  unprivileged           = var.unprivileged
+  nesting                = var.nesting
+  keyctl                 = var.keyctl
+  network_interface_name = var.network_interface_name
+  dns                    = var.dns
+  root_public_keys       = var.root_public_keys
+  root_password          = var.root_password
+  container_template     = var.container_template
+  snippet_datastore_id   = var.snippet_datastore_id
+  hook_script_content    = local.hook_script
+  hook_script_file_name  = format("%s-hook.sh", replace(var.name, ".", "-"))
+  pve_connection         = var.pve_connection
 }

--- a/modules/proxmox/shutdown-controller/outputs.tf
+++ b/modules/proxmox/shutdown-controller/outputs.tf
@@ -1,24 +1,25 @@
 output "container_vm_id" {
   description = "Proxmox VMID assigned to the shutdown controller container."
-  value       = proxmox_virtual_environment_container.this.vm_id
+  value       = module.lxc.container_vm_id
 }
 
 output "container_name" {
   description = "Hostname assigned to the shutdown controller container."
-  value       = local.container_name
+  value       = module.lxc.container_name
 }
 
 output "container_ipv4_address" {
   description = "Configured IPv4 address for the shutdown controller container."
-  value       = var.ipv4_address
+  value       = module.lxc.container_ipv4_address
 }
 
 output "container_ipv4_reported" {
   description = "IPv4 addresses reported by Proxmox for the shutdown controller container."
-  value       = proxmox_virtual_environment_container.this.ipv4
+  value       = module.lxc.container_ipv4_reported
 }
 
 output "hook_script_file_id" {
   description = "Proxmox snippet file ID for the bootstrap hook script."
-  value       = proxmox_virtual_environment_file.hook_script.id
+  value       = module.lxc.hook_script_file_id
+  sensitive   = true
 }


### PR DESCRIPTION
Adds a reusable Proxmox LXC module and refactors the existing Proxmox container-based modules to build on it.

Summary:
- add a standalone `modules/proxmox/lxc` module for single-container provisioning
- refactor `k8s-api-lb` to compose the shared LXC module
- refactor `shutdown-controller` to compose the shared LXC module
- document the Terraform provider-ownership limitation that affects nested module composition

This keeps the base LXC behavior aligned across modules while reducing duplicated container resource logic.