### PR TITLE
Add Proxmox Powerwall bridge module

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Hodgepodge of Terraform modules.
    * Actions Secrets - Deploys secrets to Github Actions. (AWS IAM User option)
 
 * Proxmox
+   * Powerwall Bridge (Deploys a pyPowerwall bridge in an LXC with optional MQTT publishing)
    * VM Clone (Create VMs from templates created by packer)
    * VM (Create VM with cloud-init and auto download ISO)
 

--- a/modules/proxmox/README.md
+++ b/modules/proxmox/README.md
@@ -2,6 +2,7 @@
 
 - [k8s-api-lb](k8s-api-lb/README.md): external API VIP for Talos or Kubernetes control planes
 - [lxc](lxc/README.md): reusable single-container building block for higher-level Proxmox modules
+- [powerwall-bridge](powerwall-bridge/README.md): LXC-based pyPowerwall proxy with optional MQTT publishing for Home Assistant
 - [shutdown-controller](shutdown-controller/README.md): LXC-based UPS and staged shutdown coordinator for Ceph, Talos, and Proxmox
 - [talos-pve](talos-pve/README.md): Talos control plane VMs on Proxmox
 - [vm](vm/): generic Proxmox VM building blocks

--- a/modules/proxmox/powerwall-bridge/README.md
+++ b/modules/proxmox/powerwall-bridge/README.md
@@ -1,0 +1,177 @@
+# Proxmox Powerwall Bridge
+
+Creates a Proxmox LXC that runs the upstream `pyPowerwall` proxy and, optionally, an MQTT publisher for Home Assistant.
+
+Uses the sibling `../lxc` module for the base container.
+
+## Services
+
+Inside the container:
+
+- `powerwall-proxy.service`: runs the upstream `pyPowerwall` HTTP proxy on port `8675`
+- `powerwall-mqtt-publisher.service`: polls the local proxy and publishes MQTT discovery and retained state snapshots
+
+If MQTT publishing is disabled, the proxy still runs and can be consumed directly over HTTP.
+
+Useful proxy endpoints:
+
+- `/aggregates`
+- `/soe`
+- `/strings`
+- `/vitals`
+- `/alerts`
+- `/alerts/pw`
+- `/health`
+
+## Host Requirements
+
+This module does not set up the Proxmox host-side path to the Powerwall. It does not configure:
+
+- host Wi-Fi association to the Powerwall access point
+- host IP forwarding
+- host NAT or firewall policy
+- Linux bridge design on the Proxmox host
+
+If your container reaches the Powerwall through the Proxmox host, host-side routing or NAT is required. A guest-side route alone is not sufficient.
+
+This repository does not currently include a public, reusable Ansible role for that host-side setup.
+
+Typical flow:
+
+1. The Proxmox host reaches the Powerwall.
+2. The container uses normal LAN networking for management and MQTT.
+3. `route_to_powerwall` sends Powerwall traffic to the Proxmox host as the next hop when needed.
+
+For Wi-Fi TEDAPI access:
+
+1. Attach the Proxmox host to the Powerwall Wi-Fi network.
+2. Verify the host can reach `192.168.91.1` reliably.
+3. Enable host forwarding or NAT from the LXC network toward the Powerwall Wi-Fi interface.
+4. Set `route_to_powerwall.gateway` to the Proxmox host IP as seen by the container.
+
+Without that host-side forwarding or NAT path, the bridge container will not be able to reach the Powerwall even if `route_to_powerwall` is configured.
+
+Firmware caveat:
+
+- Recent Powerwall firmware may block routed TEDAPI access even if the route exists.
+- In that case the host path still has to work first. `route_to_powerwall` is only a guest-side convenience.
+
+## Connectivity Modes
+
+This module passes connection settings through to pyPowerwall.
+
+Typical Powerwall 3 cases:
+
+- Wi-Fi TEDAPI with string metrics:
+  - `powerwall.host = "192.168.91.1"`
+  - `powerwall.gw_password` required
+- Wired vendor-subnet v1r access:
+  - `powerwall.host = "10.42.1.x"`
+  - `powerwall.gw_password` required
+  - `powerwall.rsa_key_content` required for the full control-style path
+- Cloud-oriented setup:
+  - set `powerwall.email`
+  - follow upstream pyPowerwall guidance if you need cloud-only behaviors
+
+## Example
+
+See [examples/basic](examples/basic) for a minimal standalone configuration.
+
+It only covers the Terraform side. You still need to build the Proxmox host-side connectivity yourself.
+
+## Usage
+
+```hcl
+module "powerwall_bridge" {
+  source = "git::https://github.com/friedcircuits/terraform-modules.git//modules/proxmox/powerwall-bridge?ref=v0.1.0"
+
+  name      = "powerwall3-bridge"
+  node_name = "pve3"
+  vm_id     = 1450
+
+  container_template = {
+    file_id = "local:vztmpl/debian-13-standard_13.1-2_amd64.tar.zst"
+    type    = "debian"
+  }
+
+  dns = {
+    domain  = "example.internal"
+    servers = ["192.168.0.1"]
+  }
+
+  root_public_keys = [file("~/.ssh/id_ed25519.pub")]
+
+  timezone = "UTC"
+
+  powerwall = {
+    host        = "192.168.91.1"
+    gw_password = var.powerwall_gateway_password
+  }
+
+  mqtt = {
+    host             = "mqtt.example.internal"
+    topic_prefix     = "powerwall/powerwall3-bridge"
+    discovery_prefix = "homeassistant"
+  }
+
+  mqtt_credentials = {
+    username = var.mqtt_username
+    password = var.mqtt_password
+  }
+
+  route_to_powerwall = {
+    gateway = "192.168.1.32"
+  }
+
+  mqtt_fetch_timeout_seconds     = 15
+  mqtt_fetch_retries             = 2
+  mqtt_fetch_retry_delay_seconds = 1.5
+  mqtt_failures_before_offline   = 5
+
+  pve_connection = {
+    endpoint     = "https://pve.example.com:8006"
+    api_user     = "terraform@pam"
+    api_password = var.proxmox_password
+  }
+}
+```
+
+## MQTT and Home Assistant
+
+When MQTT is enabled, the publisher creates one Home Assistant device and publishes a retained state payload at the configured interval.
+
+Current entity groups:
+
+
+- site telemetry: grid, home, solar, battery power, battery level, reserve, mode, grid status, firmware version
+- alerts: active alert count and summary, gateway alert count and summary, pack alert count and summary
+- solar strings: per-string power, voltage, current, state, connected status
+- battery blocks: power, voltage, frequency, inverter state, grid state, remaining/full energy, disabled reasons, disabled/backup-ready/off-grid state
+- inverter and sync vitals: inverter power, voltage, split voltages, frequency, state, sync grid connected/state, gateway location
+- fan data when present
+
+The exact data available still depends on model, firmware, and which API path works in your setup.
+
+## Validation
+
+Plan-time validation covers:
+
+- Proxmox authentication method selection
+- valid proxy and MQTT ports
+- non-empty MQTT and Powerwall credential fields when set
+- `powerwall.rsa_key_content` requiring `powerwall.gw_password`
+- route gateway formatting
+- non-negative publisher retry and backoff settings
+
+This catches common bad input combinations, not end-to-end networking mistakes.
+
+## Operational Notes
+
+- The bootstrap process clones and pins the upstream pyPowerwall repository inside the container.
+- The MQTT publisher depends on the local proxy, not on direct Powerwall access.
+- `route_to_powerwall` only installs a route inside the guest.
+- Routed access requires a separately managed host-side forwarding or NAT design.
+- The default timezone is `UTC`; set `timezone` explicitly if you want local timestamps in another zone.
+- The MQTT publisher retry and offline thresholds are configurable without editing templates.
+- MQTT discovery is retained, so changing the publisher model may require the bridge to republish or clear deprecated entities.
+- Some upstream metrics are firmware- and model-dependent. For example, Powerwall 3 temperature data may not be available from the TEDAPI controller path even when older systems expose it.

--- a/modules/proxmox/powerwall-bridge/examples/basic/main.tf
+++ b/modules/proxmox/powerwall-bridge/examples/basic/main.tf
@@ -1,0 +1,68 @@
+module "powerwall_bridge" {
+  source = "../.."
+
+  name      = "powerwall-bridge"
+  node_name = "pve1"
+  vm_id     = 1450
+
+  ipv4_address = "192.168.10.50/24"
+  gateway      = "192.168.10.1"
+  timezone     = "UTC"
+
+  container_template = {
+    file_id = "local:vztmpl/debian-13-standard_13.1-2_amd64.tar.zst"
+    type    = "debian"
+  }
+
+  dns = {
+    domain  = "example.internal"
+    servers = ["192.168.10.1"]
+  }
+
+  root_public_keys = [file("~/.ssh/id_ed25519.pub")]
+
+  powerwall = {
+    host        = "192.168.91.1"
+    gw_password = var.powerwall_gateway_password
+  }
+
+  mqtt = {
+    host             = "mqtt.example.internal"
+    topic_prefix     = "powerwall/powerwall-bridge"
+    discovery_prefix = "homeassistant"
+  }
+
+  mqtt_credentials = {
+    username = var.mqtt_username
+    password = var.mqtt_password
+  }
+
+  route_to_powerwall = {
+    gateway = "192.168.10.2"
+  }
+
+  pve_connection = {
+    endpoint     = "https://pve.example.internal:8006"
+    api_user     = "terraform@pam"
+    api_password = var.proxmox_password
+  }
+}
+
+variable "powerwall_gateway_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "mqtt_username" {
+  type = string
+}
+
+variable "mqtt_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "proxmox_password" {
+  type      = string
+  sensitive = true
+}

--- a/modules/proxmox/powerwall-bridge/locals.tf
+++ b/modules/proxmox/powerwall-bridge/locals.tf
@@ -1,0 +1,133 @@
+locals {
+  container_name = var.name
+  sanitized_name = replace(var.name, ".", "-")
+  description = coalesce(
+    var.description,
+    format("Powerwall bridge %s", var.name)
+  )
+
+  powerwall_host              = coalesce(try(var.powerwall.host, null), "192.168.91.1")
+  powerwall_gateway_password  = try(var.powerwall.gw_password, null)
+  powerwall_customer_password = try(var.powerwall.password, null)
+  powerwall_email             = try(var.powerwall.email, null)
+  powerwall_wifi_host         = try(var.powerwall.wifi_host, null)
+  powerwall_write_rsa_key     = try(var.powerwall.rsa_key_content, null) != null
+  powerwall_route_destination = var.route_to_powerwall != null ? coalesce(try(var.route_to_powerwall.destination, null), "192.168.91.1/32") : null
+  powerwall_route_interface   = var.route_to_powerwall != null ? coalesce(try(var.route_to_powerwall.interface, null), var.network_interface_name) : null
+  powerwall_route_gateway     = var.route_to_powerwall != null ? var.route_to_powerwall.gateway : null
+  powerwall_route_onlink      = var.route_to_powerwall != null ? coalesce(try(var.route_to_powerwall.onlink, null), true) : false
+  mqtt_topic_prefix           = var.mqtt != null ? coalesce(try(var.mqtt.topic_prefix, null), format("homelab/%s", var.name)) : format("homelab/%s", var.name)
+  mqtt_discovery_prefix       = var.mqtt != null ? coalesce(try(var.mqtt.discovery_prefix, null), "homeassistant") : "homeassistant"
+  mqtt_port                   = var.mqtt != null ? coalesce(try(var.mqtt.port, null), 1883) : 1883
+  mqtt_client_id              = var.mqtt != null ? coalesce(try(var.mqtt.client_id, null), format("%s-mqtt", local.sanitized_name)) : format("%s-mqtt", local.sanitized_name)
+  mqtt_retain                 = var.mqtt != null ? coalesce(try(var.mqtt.retain, null), true) : true
+
+  proxy_env = templatefile("${path.module}/templates/powerwall-proxy.env.tftpl", {
+    timezone                       = var.timezone
+    proxy_bind_address             = var.proxy_bind_address
+    proxy_port                     = var.proxy_port
+    proxy_https_mode               = var.proxy_https_mode
+    proxy_cache_expire             = var.proxy_cache_expire
+    proxy_cache_ttl                = var.proxy_cache_ttl
+    proxy_timeout                  = var.proxy_timeout
+    proxy_pool_maxsize             = var.proxy_pool_maxsize
+    proxy_fail_fast                = var.proxy_fail_fast
+    proxy_graceful_degradation     = var.proxy_graceful_degradation
+    proxy_health_check             = var.proxy_health_check
+    proxy_suppress_network_errors  = var.proxy_suppress_network_errors
+    proxy_network_error_rate_limit = var.proxy_network_error_rate_limit
+    powerwall_host                 = local.powerwall_host
+    powerwall_gateway_password     = local.powerwall_gateway_password
+    powerwall_customer_password    = local.powerwall_customer_password
+    powerwall_email                = local.powerwall_email
+    powerwall_wifi_host            = local.powerwall_wifi_host
+    write_rsa_key                  = local.powerwall_write_rsa_key
+    rsa_key_path                   = "/etc/powerwall-bridge/tedapi_rsa_private.pem"
+  })
+
+  mqtt_env = var.mqtt != null ? templatefile("${path.module}/templates/powerwall-mqtt.env.tftpl", {
+    proxy_port                       = var.proxy_port
+    mqtt_host                        = var.mqtt.host
+    mqtt_port                        = local.mqtt_port
+    mqtt_topic_prefix                = local.mqtt_topic_prefix
+    mqtt_discovery_prefix            = local.mqtt_discovery_prefix
+    mqtt_client_id                   = local.mqtt_client_id
+    mqtt_retain                      = local.mqtt_retain
+    mqtt_publish_interval_seconds    = var.mqtt_publish_interval_seconds
+    mqtt_status_log_interval_seconds = var.mqtt_status_log_interval_seconds
+    mqtt_failures_before_offline     = var.mqtt_failures_before_offline
+    mqtt_fetch_timeout_seconds       = var.mqtt_fetch_timeout_seconds
+    mqtt_fetch_retries               = var.mqtt_fetch_retries
+    mqtt_fetch_retry_delay_seconds   = var.mqtt_fetch_retry_delay_seconds
+    mqtt_credentials                 = var.mqtt_credentials
+    device_id                        = local.sanitized_name
+    device_name                      = var.name
+  }) : null
+
+  proxy_service_unit = templatefile("${path.module}/templates/powerwall-proxy.service.tftpl", {
+    env_file = "/etc/powerwall-bridge/proxy.env"
+  })
+
+  mqtt_service_unit = var.mqtt != null ? templatefile("${path.module}/templates/powerwall-mqtt-publisher.service.tftpl", {
+    env_file       = "/etc/powerwall-bridge/mqtt.env"
+    publisher_path = "/usr/local/lib/powerwall-bridge/mqtt_publisher.py"
+  }) : null
+
+  route_service_unit = var.route_to_powerwall != null ? templatefile("${path.module}/templates/powerwall-route.service.tftpl", {
+    destination = local.powerwall_route_destination
+    gateway     = local.powerwall_route_gateway
+    interface   = local.powerwall_route_interface
+    onlink      = local.powerwall_route_onlink
+  }) : null
+
+  mqtt_publisher_script = var.mqtt != null ? templatefile("${path.module}/templates/mqtt_publisher.py.tftpl", {
+    device_id        = local.sanitized_name
+    device_name      = var.name
+    proxy_port       = var.proxy_port
+    topic_prefix     = local.mqtt_topic_prefix
+    discovery_prefix = local.mqtt_discovery_prefix
+  }) : null
+
+  bootstrap_script = templatefile("${path.module}/templates/bootstrap.sh.tftpl", {
+    packages                  = join(" ", var.packages)
+    repo_ref                  = var.pypowerwall_repo_ref
+    proxy_env_b64             = base64encode(local.proxy_env)
+    proxy_service_unit_b64    = base64encode(local.proxy_service_unit)
+    mqtt_env_b64              = local.mqtt_env != null ? base64encode(local.mqtt_env) : ""
+    mqtt_service_unit_b64     = local.mqtt_service_unit != null ? base64encode(local.mqtt_service_unit) : ""
+    mqtt_publisher_script_b64 = local.mqtt_publisher_script != null ? base64encode(local.mqtt_publisher_script) : ""
+    route_service_unit_b64    = local.route_service_unit != null ? base64encode(local.route_service_unit) : ""
+    rsa_key_b64               = local.powerwall_write_rsa_key ? base64encode(var.powerwall.rsa_key_content) : ""
+    write_rsa_key             = local.powerwall_write_rsa_key
+    enable_proxy_service      = var.enable_proxy_service
+    enable_mqtt_publisher     = var.enable_mqtt_publisher && var.mqtt != null
+    enable_route_service      = var.route_to_powerwall != null
+  })
+
+  hook_script = <<-EOT
+    #!/bin/sh
+    set -eu
+
+    vmid="$1"
+    phase="$2"
+
+    if [ "$phase" != "post-start" ]; then
+      exit 0
+    fi
+
+    attempts=0
+    until pct exec "$vmid" -- sh -lc 'true' >/dev/null 2>&1; do
+      attempts=$((attempts + 1))
+      if [ "$attempts" -ge 30 ]; then
+        echo "container $vmid did not become ready for pct exec" >&2
+        exit 1
+      fi
+      sleep 2
+    done
+
+    pct exec "$vmid" -- sh -lc 'install -d -m 0755 /usr/local/sbin'
+    pct exec "$vmid" -- sh -lc 'printf %s '"'"'${base64encode(local.bootstrap_script)}'"'"' | base64 -d >/usr/local/sbin/powerwall-bridge-bootstrap.sh
+chmod 0755 /usr/local/sbin/powerwall-bridge-bootstrap.sh
+sh /usr/local/sbin/powerwall-bridge-bootstrap.sh'
+  EOT
+}

--- a/modules/proxmox/powerwall-bridge/main.tf
+++ b/modules/proxmox/powerwall-bridge/main.tf
@@ -1,0 +1,42 @@
+module "lxc" {
+  source = "../lxc"
+
+  name                   = local.container_name
+  node_name              = var.node_name
+  ipv4_address           = var.ipv4_address
+  gateway                = var.gateway
+  vm_id                  = var.vm_id
+  description            = local.description
+  bridge                 = var.bridge
+  vlan_id                = var.vlan_id
+  mac_address            = var.mac_address
+  mtu                    = var.mtu
+  firewall               = var.firewall
+  rate_limit             = var.rate_limit
+  datastore_id           = var.datastore_id
+  disk_size_gb           = var.disk_size_gb
+  cpu_cores              = var.cpu_cores
+  cpu_units              = var.cpu_units
+  cpu_limit              = var.cpu_limit
+  memory_mb              = var.memory_mb
+  swap_mb                = var.swap_mb
+  tags                   = var.tags
+  protection             = var.protection
+  startup_order          = var.startup_order
+  startup_up_delay       = var.startup_up_delay
+  startup_down_delay     = var.startup_down_delay
+  started                = var.started
+  start_on_boot          = var.start_on_boot
+  unprivileged           = var.unprivileged
+  nesting                = var.nesting
+  keyctl                 = var.keyctl
+  network_interface_name = var.network_interface_name
+  dns                    = var.dns
+  root_public_keys       = var.root_public_keys
+  root_password          = var.root_password
+  container_template     = var.container_template
+  snippet_datastore_id   = var.snippet_datastore_id
+  hook_script_content    = local.hook_script
+  hook_script_file_name  = format("%s-hook.sh", local.sanitized_name)
+  pve_connection         = var.pve_connection
+}

--- a/modules/proxmox/powerwall-bridge/outputs.tf
+++ b/modules/proxmox/powerwall-bridge/outputs.tf
@@ -1,0 +1,35 @@
+output "container_vm_id" {
+  description = "Proxmox VMID assigned to the Powerwall bridge container."
+  value       = module.lxc.container_vm_id
+}
+
+output "container_name" {
+  description = "Hostname assigned to the Powerwall bridge container."
+  value       = module.lxc.container_name
+}
+
+output "container_ipv4_address" {
+  description = "Configured IPv4 address for the Powerwall bridge container."
+  value       = module.lxc.container_ipv4_address
+}
+
+output "container_ipv4_reported" {
+  description = "IPv4 addresses reported by Proxmox for the Powerwall bridge container."
+  value       = module.lxc.container_ipv4_reported
+}
+
+output "proxy_port" {
+  description = "TCP port exposed by the pyPowerwall proxy."
+  value       = var.proxy_port
+}
+
+output "mqtt_topic_prefix" {
+  description = "MQTT topic prefix used by the Home Assistant bridge publisher."
+  value       = local.mqtt_topic_prefix
+}
+
+output "hook_script_file_id" {
+  description = "Proxmox snippet file ID for the bootstrap hook script."
+  value       = module.lxc.hook_script_file_id
+  sensitive   = true
+}

--- a/modules/proxmox/powerwall-bridge/templates/bootstrap.sh.tftpl
+++ b/modules/proxmox/powerwall-bridge/templates/bootstrap.sh.tftpl
@@ -1,0 +1,80 @@
+#!/bin/sh
+set -eu
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y ${packages}
+
+install -d -m 0755 /etc/powerwall-bridge /opt/powerwall-bridge /usr/local/lib/powerwall-bridge /var/lib/powerwall-bridge
+
+if [ ! -d /opt/powerwall-bridge/src/.git ]; then
+  rm -rf /opt/powerwall-bridge/src
+  git clone https://github.com/jasonacox/pypowerwall.git /opt/powerwall-bridge/src
+fi
+
+git -C /opt/powerwall-bridge/src fetch --force origin
+git -C /opt/powerwall-bridge/src fetch --tags --force origin
+git -C /opt/powerwall-bridge/src checkout --force ${repo_ref}
+
+python3 -m venv /opt/powerwall-bridge/venv
+/opt/powerwall-bridge/venv/bin/pip install --upgrade pip
+/opt/powerwall-bridge/venv/bin/pip install --no-cache-dir -r /opt/powerwall-bridge/src/proxy/requirements.txt paho-mqtt==2.1.0
+
+printf %s '${proxy_env_b64}' | base64 -d >/etc/powerwall-bridge/proxy.env
+chmod 0600 /etc/powerwall-bridge/proxy.env
+
+printf %s '${proxy_service_unit_b64}' | base64 -d >/etc/systemd/system/powerwall-proxy.service
+chmod 0644 /etc/systemd/system/powerwall-proxy.service
+
+%{ if write_rsa_key ~}
+printf %s '${rsa_key_b64}' | base64 -d >/etc/powerwall-bridge/tedapi_rsa_private.pem
+chmod 0600 /etc/powerwall-bridge/tedapi_rsa_private.pem
+%{ else ~}
+rm -f /etc/powerwall-bridge/tedapi_rsa_private.pem
+%{ endif ~}
+
+%{ if enable_mqtt_publisher ~}
+printf %s '${mqtt_env_b64}' | base64 -d >/etc/powerwall-bridge/mqtt.env
+chmod 0600 /etc/powerwall-bridge/mqtt.env
+
+printf %s '${mqtt_publisher_script_b64}' | base64 -d >/usr/local/lib/powerwall-bridge/mqtt_publisher.py
+chmod 0755 /usr/local/lib/powerwall-bridge/mqtt_publisher.py
+
+printf %s '${mqtt_service_unit_b64}' | base64 -d >/etc/systemd/system/powerwall-mqtt-publisher.service
+chmod 0644 /etc/systemd/system/powerwall-mqtt-publisher.service
+%{ else ~}
+rm -f /etc/powerwall-bridge/mqtt.env
+rm -f /usr/local/lib/powerwall-bridge/mqtt_publisher.py
+rm -f /etc/systemd/system/powerwall-mqtt-publisher.service
+%{ endif ~}
+
+%{ if enable_route_service ~}
+printf %s '${route_service_unit_b64}' | base64 -d >/etc/systemd/system/powerwall-route.service
+chmod 0644 /etc/systemd/system/powerwall-route.service
+%{ else ~}
+rm -f /etc/systemd/system/powerwall-route.service
+%{ endif ~}
+
+systemctl daemon-reload
+
+%{ if enable_route_service ~}
+systemctl enable powerwall-route.service >/dev/null 2>&1 || true
+systemctl restart powerwall-route.service
+%{ else ~}
+systemctl disable powerwall-route.service >/dev/null 2>&1 || true
+%{ endif ~}
+
+%{ if enable_proxy_service ~}
+systemctl enable powerwall-proxy.service >/dev/null 2>&1 || true
+systemctl restart powerwall-proxy.service
+%{ else ~}
+systemctl disable powerwall-proxy.service >/dev/null 2>&1 || true
+%{ endif ~}
+
+%{ if enable_mqtt_publisher ~}
+systemctl enable powerwall-mqtt-publisher.service >/dev/null 2>&1 || true
+systemctl restart powerwall-mqtt-publisher.service
+%{ else ~}
+systemctl disable powerwall-mqtt-publisher.service >/dev/null 2>&1 || true
+%{ endif ~}

--- a/modules/proxmox/powerwall-bridge/templates/mqtt_publisher.py.tftpl
+++ b/modules/proxmox/powerwall-bridge/templates/mqtt_publisher.py.tftpl
@@ -1,0 +1,1019 @@
+#!/usr/bin/env python3
+import json
+import os
+import re
+import signal
+import sys
+import time
+import traceback
+import urllib.error
+import urllib.request
+
+import paho.mqtt.client as mqtt
+
+
+PROXY_URL = os.environ.get("PROXY_URL", "http://127.0.0.1:${proxy_port}").rstrip("/")
+MQTT_HOST = os.environ["MQTT_HOST"]
+MQTT_PORT = int(os.environ.get("MQTT_PORT", "1883"))
+MQTT_TOPIC_PREFIX = os.environ.get("MQTT_TOPIC_PREFIX", "${topic_prefix}")
+MQTT_DISCOVERY_PREFIX = os.environ.get("MQTT_DISCOVERY_PREFIX", "${discovery_prefix}")
+MQTT_CLIENT_ID = os.environ.get("MQTT_CLIENT_ID", "${device_id}-mqtt")
+MQTT_USERNAME = os.environ.get("MQTT_USERNAME")
+MQTT_PASSWORD = os.environ.get("MQTT_PASSWORD")
+MQTT_RETAIN = os.environ.get("MQTT_RETAIN", "true").lower() == "true"
+PUBLISH_INTERVAL = int(os.environ.get("MQTT_PUBLISH_INTERVAL_SECONDS", "30"))
+STATUS_LOG_INTERVAL_SECONDS = int(os.environ.get("MQTT_STATUS_LOG_INTERVAL_SECONDS", "900"))
+FAILURES_BEFORE_OFFLINE = int(os.environ.get("MQTT_FAILURES_BEFORE_OFFLINE", "5"))
+FETCH_TIMEOUT_SECONDS = float(os.environ.get("MQTT_FETCH_TIMEOUT_SECONDS", "15"))
+FETCH_RETRIES = int(os.environ.get("MQTT_FETCH_RETRIES", "2"))
+FETCH_RETRY_DELAY_SECONDS = float(os.environ.get("MQTT_FETCH_RETRY_DELAY_SECONDS", "1.5"))
+DEVICE_ID = os.environ.get("DEVICE_ID", "${device_id}")
+DEVICE_NAME = os.environ.get("DEVICE_NAME", "${device_name}")
+
+STATE_TOPIC = f"{MQTT_TOPIC_PREFIX}/state"
+AVAILABILITY_TOPIC = f"{MQTT_TOPIC_PREFIX}/availability"
+
+DEVICE = {
+    "identifiers": [DEVICE_ID],
+    "name": DEVICE_NAME,
+    "manufacturer": "Jason Cox",
+    "model": "pyPowerwall Bridge",
+    "sw_version": "pyPowerwall proxy",
+}
+
+IGNORED_ALERT_CODES = {
+    "FWUpdateSucceeded",
+    "SystemConnectedToGrid",
+}
+
+DEPRECATED_DISCOVERY_ENTITIES = [
+    {"component": "sensor", "object_id": "latest_alert_summary"},
+    {"component": "sensor", "object_id": "latest_alert_code"},
+    {"component": "sensor", "object_id": "fan1_actual"},
+    {"component": "sensor", "object_id": "fan1_target"},
+    {"component": "sensor", "object_id": "fan2_actual"},
+    {"component": "sensor", "object_id": "fan2_target"},
+]
+
+STATIC_SENSORS = [
+    {
+        "component": "sensor",
+        "object_id": "grid_power",
+        "name": "Grid Power",
+        "unit_of_measurement": "W",
+        "device_class": "power",
+        "state_class": "measurement",
+        "icon": "mdi:transmission-tower",
+        "value_template": "{{ value_json.aggregates.site.instant_power if value_json.aggregates.site is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "home_power",
+        "name": "Home Power",
+        "unit_of_measurement": "W",
+        "device_class": "power",
+        "state_class": "measurement",
+        "icon": "mdi:home-lightning-bolt",
+        "value_template": "{{ value_json.aggregates.load.instant_power if value_json.aggregates.load is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "solar_power",
+        "name": "Solar Power",
+        "unit_of_measurement": "W",
+        "device_class": "power",
+        "state_class": "measurement",
+        "icon": "mdi:solar-power",
+        "value_template": "{{ value_json.aggregates.solar.instant_power if value_json.aggregates.solar is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "battery_power",
+        "name": "Battery Power",
+        "unit_of_measurement": "W",
+        "device_class": "power",
+        "state_class": "measurement",
+        "icon": "mdi:battery-charging-medium",
+        "value_template": "{{ value_json.aggregates.battery.instant_power if value_json.aggregates.battery is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "battery_level",
+        "name": "Battery Level",
+        "unit_of_measurement": "%",
+        "device_class": "battery",
+        "state_class": "measurement",
+        "icon": "mdi:battery",
+        "value_template": "{{ value_json.soe.percentage if value_json.soe.percentage is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "battery_reserve",
+        "name": "Battery Reserve",
+        "unit_of_measurement": "%",
+        "device_class": "battery",
+        "state_class": "measurement",
+        "icon": "mdi:battery-lock",
+        "value_template": "{{ value_json.reserve.reserve if value_json.reserve is mapping and value_json.reserve.reserve is defined else value_json.reserve if value_json.reserve is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "battery_mode",
+        "name": "Battery Mode",
+        "icon": "mdi:battery-cog",
+        "value_template": "{{ value_json.mode.mode if value_json.mode is mapping and value_json.mode.mode is defined else value_json.mode if value_json.mode is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "firmware_version",
+        "name": "Firmware Version",
+        "icon": "mdi:chip",
+        "value_template": "{{ value_json.version.version if value_json.version is mapping and value_json.version.version is defined else value_json.version.tag if value_json.version is mapping and value_json.version.tag is defined else value_json.version if value_json.version is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "grid_status",
+        "name": "Grid Status",
+        "icon": "mdi:transmission-tower-export",
+        "value_template": "{{ value_json.grid_status.grid_status if value_json.grid_status is mapping and value_json.grid_status.grid_status is defined else value_json.grid_status if value_json.grid_status is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "alert_count",
+        "name": "Active Alert Count",
+        "icon": "mdi:alert-circle-outline",
+        "state_class": "measurement",
+        "value_template": "{{ value_json.alert_count if value_json.alert_count is defined else none }}",
+    },
+    {
+        "component": "binary_sensor",
+        "object_id": "alerts_active",
+        "name": "Alerts Active",
+        "device_class": "problem",
+        "icon": "mdi:alert",
+        "value_template": "{{ 'ON' if value_json.alert_count is defined and value_json.alert_count > 0 else 'OFF' }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "active_alerts_summary",
+        "name": "Active Alerts Summary",
+        "icon": "mdi:format-list-bulleted-square",
+        "value_template": "{{ value_json.active_alerts_summary | join(', ') if value_json.active_alerts_summary is mapping else value_json.active_alerts_summary if value_json.active_alerts_summary is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "battery_block_count",
+        "name": "Battery Block Count",
+        "icon": "mdi:battery-multiple",
+        "state_class": "measurement",
+        "value_template": "{{ value_json.battery_block_count if value_json.battery_block_count is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "battery_energy_to_charge",
+        "name": "Battery Energy To Charge",
+        "unit_of_measurement": "Wh",
+        "device_class": "energy",
+        "state_class": "measurement",
+        "icon": "mdi:battery-plus",
+        "value_template": "{{ value_json.vitals.pack.energy_to_charge if value_json.vitals is defined and value_json.vitals.pack is defined and value_json.vitals.pack.energy_to_charge is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "battery_inverter_power",
+        "name": "Battery Inverter Power",
+        "unit_of_measurement": "W",
+        "device_class": "power",
+        "state_class": "measurement",
+        "icon": "mdi:battery-sync",
+        "value_template": "{{ value_json.vitals.inverter.power if value_json.vitals is defined and value_json.vitals.inverter is defined and value_json.vitals.inverter.power is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "battery_inverter_voltage",
+        "name": "Battery Inverter Voltage",
+        "unit_of_measurement": "V",
+        "device_class": "voltage",
+        "state_class": "measurement",
+        "icon": "mdi:sine-wave",
+        "value_template": "{{ value_json.vitals.inverter.voltage if value_json.vitals is defined and value_json.vitals.inverter is defined and value_json.vitals.inverter.voltage is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "battery_inverter_split1_voltage",
+        "name": "Battery Inverter Split 1 Voltage",
+        "unit_of_measurement": "V",
+        "device_class": "voltage",
+        "state_class": "measurement",
+        "icon": "mdi:flash-triangle",
+        "value_template": "{{ value_json.vitals.inverter.split1_voltage if value_json.vitals is defined and value_json.vitals.inverter is defined and value_json.vitals.inverter.split1_voltage is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "battery_inverter_split2_voltage",
+        "name": "Battery Inverter Split 2 Voltage",
+        "unit_of_measurement": "V",
+        "device_class": "voltage",
+        "state_class": "measurement",
+        "icon": "mdi:flash-triangle",
+        "value_template": "{{ value_json.vitals.inverter.split2_voltage if value_json.vitals is defined and value_json.vitals.inverter is defined and value_json.vitals.inverter.split2_voltage is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "battery_inverter_frequency",
+        "name": "Battery Inverter Frequency",
+        "unit_of_measurement": "Hz",
+        "device_class": "frequency",
+        "state_class": "measurement",
+        "icon": "mdi:current-ac",
+        "value_template": "{{ value_json.vitals.inverter.frequency if value_json.vitals is defined and value_json.vitals.inverter is defined and value_json.vitals.inverter.frequency is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "battery_inverter_state",
+        "name": "Battery Inverter State",
+        "icon": "mdi:state-machine",
+        "value_template": "{{ value_json.vitals.inverter.state if value_json.vitals is defined and value_json.vitals.inverter is defined and value_json.vitals.inverter.state is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "sync_grid_connected",
+        "name": "Sync Grid Connected",
+        "icon": "mdi:transmission-tower-check",
+        "value_template": "{{ value_json.vitals.sync.grid_connected if value_json.vitals is defined and value_json.vitals.sync is defined and value_json.vitals.sync.grid_connected is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "sync_grid_state",
+        "name": "Sync Grid State",
+        "icon": "mdi:transmission-tower",
+        "value_template": "{{ value_json.vitals.sync.grid_state if value_json.vitals is defined and value_json.vitals.sync is defined and value_json.vitals.sync.grid_state is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "gateway_location",
+        "name": "Gateway Location",
+        "icon": "mdi:map-marker",
+        "value_template": "{{ value_json.vitals.gateway.location if value_json.vitals is defined and value_json.vitals.gateway is defined and value_json.vitals.gateway.location is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "gateway_alert_count",
+        "name": "Gateway Alert Count",
+        "icon": "mdi:alert-circle-outline",
+        "state_class": "measurement",
+        "value_template": "{{ value_json.gateway_alert_count if value_json.gateway_alert_count is defined else none }}",
+    },
+    {
+        "component": "binary_sensor",
+        "object_id": "gateway_alerts_active",
+        "name": "Gateway Alerts Active",
+        "device_class": "problem",
+        "icon": "mdi:alert",
+        "value_template": "{{ 'ON' if value_json.gateway_alert_count is defined and value_json.gateway_alert_count > 0 else 'OFF' }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "gateway_alerts_summary",
+        "name": "Gateway Alerts Summary",
+        "icon": "mdi:alert-box-outline",
+        "value_template": "{{ value_json.gateway_alerts_summary if value_json.gateway_alerts_summary is defined else none }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "pack_alert_count",
+        "name": "Pack Alert Count",
+        "icon": "mdi:alert-circle-outline",
+        "state_class": "measurement",
+        "value_template": "{{ value_json.pack_alert_count if value_json.pack_alert_count is defined else none }}",
+    },
+    {
+        "component": "binary_sensor",
+        "object_id": "pack_alerts_active",
+        "name": "Pack Alerts Active",
+        "device_class": "problem",
+        "icon": "mdi:alert",
+        "value_template": "{{ 'ON' if value_json.pack_alert_count is defined and value_json.pack_alert_count > 0 else 'OFF' }}",
+    },
+    {
+        "component": "sensor",
+        "object_id": "pack_alerts_summary",
+        "name": "Pack Alerts Summary",
+        "icon": "mdi:battery-alert",
+        "value_template": "{{ value_json.pack_alerts_summary if value_json.pack_alerts_summary is defined else none }}",
+    },
+]
+
+
+def sanitize(value: str) -> str:
+    return re.sub(r"[^a-z0-9_]+", "_", value.lower()).strip("_")
+
+
+ENTITY_PREFIX = sanitize(DEVICE_ID) or "powerwall_bridge"
+
+
+def scoped_object_id(object_id: str) -> str:
+    return f"{ENTITY_PREFIX}_{object_id}"
+
+
+def fetch_json(path: str):
+    url = f"{PROXY_URL}{path}"
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    attempts = FETCH_RETRIES + 1
+    last_error = None
+    payload = ""
+
+    for attempt in range(1, attempts + 1):
+        try:
+            with urllib.request.urlopen(request, timeout=FETCH_TIMEOUT_SECONDS) as response:
+                payload = response.read().decode("utf-8").strip()
+            break
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(f"proxy HTTP error for {path} ({url}): {exc.code} {exc.reason}") from exc
+        except urllib.error.URLError as exc:
+            last_error = RuntimeError(
+                f"proxy request failed for {path} ({url}) attempt {attempt}/{attempts}: {exc.reason}"
+            )
+        except TimeoutError as exc:
+            last_error = RuntimeError(
+                f"proxy request timed out for {path} ({url}) attempt {attempt}/{attempts} after {FETCH_TIMEOUT_SECONDS:.1f}s"
+            )
+        except Exception as exc:
+            last_error = RuntimeError(
+                f"proxy request failed for {path} ({url}) attempt {attempt}/{attempts}: {exc}"
+            )
+
+        if attempt >= attempts:
+            raise last_error
+
+        time.sleep(FETCH_RETRY_DELAY_SECONDS * attempt)
+
+    if not payload or payload == "null":
+        return {}
+    return json.loads(payload)
+
+
+def discovery_topic(component: str, object_id: str) -> str:
+    scoped_id = scoped_object_id(object_id)
+    return f"{MQTT_DISCOVERY_PREFIX}/{component}/{DEVICE_ID}/{scoped_id}/config"
+
+
+def publish_discovery(client: mqtt.Client, definition: dict) -> None:
+    scoped_id = scoped_object_id(definition["object_id"])
+    payload = {
+        "name": definition["name"],
+        "object_id": scoped_id,
+        "unique_id": f"{DEVICE_ID}_{scoped_id}",
+        "state_topic": STATE_TOPIC,
+        "value_template": definition["value_template"],
+        "availability_topic": AVAILABILITY_TOPIC,
+        "payload_available": "online",
+        "payload_not_available": "offline",
+        "device": DEVICE,
+    }
+    for key in ["unit_of_measurement", "device_class", "state_class", "icon"]:
+        value = definition.get(key)
+        if value is not None:
+            payload[key] = value
+    if definition["component"] == "binary_sensor":
+        payload["payload_on"] = "ON"
+        payload["payload_off"] = "OFF"
+    client.publish(discovery_topic(definition["component"], definition["object_id"]), json.dumps(payload), retain=True)
+
+
+def clear_discovery(client: mqtt.Client, component: str, object_id: str) -> None:
+    client.publish(discovery_topic(component, object_id), "", retain=True)
+
+
+def publish_string_discovery(client: mqtt.Client, string_name: str) -> None:
+    string_key = sanitize(string_name)
+    label = string_name.upper()
+    definitions = [
+        {
+            "component": "sensor",
+            "object_id": f"string_{string_key}_power",
+            "name": f"String {label} Power",
+            "unit_of_measurement": "W",
+            "device_class": "power",
+            "state_class": "measurement",
+            "icon": "mdi:solar-power-variant",
+            "value_template": f"{{{{ value_json.strings.{string_name}.Power if value_json.strings.{string_name} is defined else none }}}}",
+        },
+        {
+            "component": "sensor",
+            "object_id": f"string_{string_key}_voltage",
+            "name": f"String {label} Voltage",
+            "unit_of_measurement": "V",
+            "device_class": "voltage",
+            "state_class": "measurement",
+            "icon": "mdi:sine-wave",
+            "value_template": f"{{{{ value_json.strings.{string_name}.Voltage if value_json.strings.{string_name} is defined else none }}}}",
+        },
+        {
+            "component": "sensor",
+            "object_id": f"string_{string_key}_current",
+            "name": f"String {label} Current",
+            "unit_of_measurement": "A",
+            "device_class": "current",
+            "state_class": "measurement",
+            "icon": "mdi:current-dc",
+            "value_template": f"{{{{ value_json.strings.{string_name}.Current if value_json.strings.{string_name} is defined else none }}}}",
+        },
+        {
+            "component": "sensor",
+            "object_id": f"string_{string_key}_state",
+            "name": f"String {label} State",
+            "icon": "mdi:solar-panel-large",
+            "value_template": f"{{{{ value_json.strings.{string_name}.State if value_json.strings.{string_name} is defined else none }}}}",
+        },
+        {
+            "component": "binary_sensor",
+            "object_id": f"string_{string_key}_connected",
+            "name": f"String {label} Connected",
+            "device_class": "connectivity",
+            "icon": "mdi:lan-connect",
+            "value_template": f"{{{{ 'ON' if value_json.strings.{string_name}.Connected else 'OFF' if value_json.strings.{string_name} is defined else 'OFF' }}}}",
+        },
+    ]
+    for definition in definitions:
+        publish_discovery(client, definition)
+
+
+def publish_battery_block_discovery(client: mqtt.Client, block_name: str) -> None:
+    block_key = sanitize(block_name)
+    definitions = [
+        {
+            "component": "sensor",
+            "object_id": f"battery_block_{block_key}_power",
+            "name": f"Battery Block {block_name} Power",
+            "unit_of_measurement": "W",
+            "device_class": "power",
+            "state_class": "measurement",
+            "icon": "mdi:battery-charging-outline",
+            "value_template": f"{{{{ value_json.battery_blocks.get('{block_name}', {{}}).get('p_out') if value_json.battery_blocks is defined else none }}}}",
+        },
+        {
+            "component": "sensor",
+            "object_id": f"battery_block_{block_key}_voltage",
+            "name": f"Battery Block {block_name} Voltage",
+            "unit_of_measurement": "V",
+            "device_class": "voltage",
+            "state_class": "measurement",
+            "icon": "mdi:sine-wave",
+            "value_template": f"{{{{ value_json.battery_blocks.get('{block_name}', {{}}).get('v_out') if value_json.battery_blocks is defined else none }}}}",
+        },
+        {
+            "component": "sensor",
+            "object_id": f"battery_block_{block_key}_frequency",
+            "name": f"Battery Block {block_name} Frequency",
+            "unit_of_measurement": "Hz",
+            "device_class": "frequency",
+            "state_class": "measurement",
+            "icon": "mdi:current-ac",
+            "value_template": f"{{{{ value_json.battery_blocks.get('{block_name}', {{}}).get('f_out') if value_json.battery_blocks is defined else none }}}}",
+        },
+        {
+            "component": "sensor",
+            "object_id": f"battery_block_{block_key}_nominal_energy_remaining",
+            "name": f"Battery Block {block_name} Remaining Energy",
+            "unit_of_measurement": "Wh",
+            "device_class": "energy",
+            "state_class": "measurement",
+            "icon": "mdi:battery-medium",
+            "value_template": f"{{{{ value_json.battery_blocks.get('{block_name}', {{}}).get('nominal_energy_remaining') if value_json.battery_blocks is defined else none }}}}",
+        },
+        {
+            "component": "sensor",
+            "object_id": f"battery_block_{block_key}_pinv_state",
+            "name": f"Battery Block {block_name} Inverter State",
+            "icon": "mdi:state-machine",
+            "value_template": f"{{{{ value_json.battery_blocks.get('{block_name}', {{}}).get('pinv_state') if value_json.battery_blocks is defined else none }}}}",
+        },
+        {
+            "component": "sensor",
+            "object_id": f"battery_block_{block_key}_grid_state",
+            "name": f"Battery Block {block_name} Grid State",
+            "icon": "mdi:transmission-tower",
+            "value_template": f"{{{{ value_json.battery_blocks.get('{block_name}', {{}}).get('pinv_grid_state') if value_json.battery_blocks is defined else none }}}}",
+        },
+        {
+            "component": "sensor",
+            "object_id": f"battery_block_{block_key}_package_part_number",
+            "name": f"Battery Block {block_name} Package Part Number",
+            "icon": "mdi:identifier",
+            "value_template": f"{{{{ value_json.battery_blocks.get('{block_name}', {{}}).get('PackagePartNumber') if value_json.battery_blocks is defined else none }}}}",
+        },
+        {
+            "component": "sensor",
+            "object_id": f"battery_block_{block_key}_type",
+            "name": f"Battery Block {block_name} Type",
+            "icon": "mdi:battery-outline",
+            "value_template": f"{{{{ value_json.battery_blocks.get('{block_name}', {{}}).get('Type') if value_json.battery_blocks is defined else none }}}}",
+        },
+        {
+            "component": "sensor",
+            "object_id": f"battery_block_{block_key}_nominal_full_energy",
+            "name": f"Battery Block {block_name} Full Energy",
+            "unit_of_measurement": "Wh",
+            "device_class": "energy",
+            "state_class": "measurement",
+            "icon": "mdi:battery-high",
+            "value_template": f"{{{{ value_json.battery_blocks.get('{block_name}', {{}}).get('nominal_full_pack_energy') if value_json.battery_blocks is defined else none }}}}",
+        },
+        {
+            "component": "sensor",
+            "object_id": f"battery_block_{block_key}_disabled_reasons_count",
+            "name": f"Battery Block {block_name} Disabled Reason Count",
+            "icon": "mdi:alert-circle-outline",
+            "state_class": "measurement",
+            "value_template": f"{{{{ value_json.battery_blocks.get('{block_name}', {{}}).get('disabled_reasons', []) | count if value_json.battery_blocks is defined else none }}}}",
+        },
+        {
+            "component": "sensor",
+            "object_id": f"battery_block_{block_key}_disabled_reasons",
+            "name": f"Battery Block {block_name} Disabled Reasons",
+            "icon": "mdi:alert-box-outline",
+            "value_template": f"{{{{ value_json.battery_blocks.get('{block_name}', {{}}).get('disabled_reasons', []) | join('; ') if value_json.battery_blocks is defined else none }}}}",
+        },
+        {
+            "component": "binary_sensor",
+            "object_id": f"battery_block_{block_key}_disabled",
+            "name": f"Battery Block {block_name} Disabled",
+            "device_class": "problem",
+            "icon": "mdi:battery-off-outline",
+            "value_template": f"{{{{ 'ON' if value_json.battery_blocks is defined and value_json.battery_blocks.get('{block_name}', {{}}).get('disabled_reasons', []) | count > 0 else 'OFF' }}}}",
+        },
+        {
+            "component": "binary_sensor",
+            "object_id": f"battery_block_{block_key}_backup_ready",
+            "name": f"Battery Block {block_name} Backup Ready",
+            "icon": "mdi:battery-check",
+            "value_template": f"{{{{ 'ON' if value_json.battery_blocks is defined and value_json.battery_blocks.get('{block_name}', {{}}).get('backup_ready') else 'OFF' if value_json.battery_blocks is defined and value_json.battery_blocks.get('{block_name}', {{}}).get('backup_ready') is sameas false else none }}}}",
+        },
+        {
+            "component": "binary_sensor",
+            "object_id": f"battery_block_{block_key}_off_grid",
+            "name": f"Battery Block {block_name} Off Grid",
+            "device_class": "power",
+            "icon": "mdi:transmission-tower-off",
+            "value_template": f"{{{{ 'ON' if value_json.battery_blocks is defined and value_json.battery_blocks.get('{block_name}', {{}}).get('off_grid') else 'OFF' if value_json.battery_blocks is defined and value_json.battery_blocks.get('{block_name}', {{}}).get('off_grid') is sameas false else none }}}}",
+        },
+    ]
+    for definition in definitions:
+        publish_discovery(client, definition)
+
+
+def prefer_current_value(current, previous):
+    if current is None:
+        return previous
+    if isinstance(current, dict) and not current:
+        return previous if previous is not None else {}
+    if isinstance(current, list) and not current:
+        return previous if previous is not None else []
+    if current == "":
+        return previous
+    return current
+
+
+def normalize_reserve(value):
+    if isinstance(value, dict):
+        for key in ["reserve", "value", "percentage"]:
+            nested = value.get(key)
+            if isinstance(nested, (int, float, str)):
+                return nested
+        return None
+    if isinstance(value, (int, float, str)):
+        return value
+    return None
+
+
+def normalize_mode(value):
+    if isinstance(value, dict):
+        nested = value.get("mode")
+        if isinstance(nested, str):
+            return nested
+        return None
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def normalize_version(value):
+    if isinstance(value, dict):
+        for key in ["version", "tag"]:
+            nested = value.get(key)
+            if isinstance(nested, str):
+                return nested
+        return None
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def normalize_grid_status(value):
+    if isinstance(value, dict):
+        nested = value.get("grid_status")
+        if isinstance(nested, str):
+            return nested
+        return None
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def normalize_vitals(value):
+    if not isinstance(value, dict):
+        return {}
+
+    vitals = {
+        "gateway": {},
+        "inverter": {},
+        "pack": {},
+        "sync": {},
+    }
+
+    for component_name, component_data in value.items():
+        if not isinstance(component_data, dict):
+            continue
+
+        if component_name.startswith("STSTSM"):
+            location = component_data.get("STSTSM-Location")
+            if isinstance(location, str) and location:
+                vitals["gateway"]["location"] = location
+            if isinstance(component_data.get("alerts"), list):
+                vitals["gateway"]["alerts"] = [label for item in component_data["alerts"] if (label := normalize_alert_label(item)) is not None]
+
+        if component_name.startswith("TEPINV"):
+            if isinstance(component_data.get("PINV_Pout"), (int, float)):
+                vitals["inverter"]["power"] = component_data["PINV_Pout"]
+            if isinstance(component_data.get("PINV_Vout"), (int, float)):
+                vitals["inverter"]["voltage"] = component_data["PINV_Vout"]
+            if isinstance(component_data.get("PINV_VSplit1"), (int, float)):
+                vitals["inverter"]["split1_voltage"] = component_data["PINV_VSplit1"]
+            if isinstance(component_data.get("PINV_VSplit2"), (int, float)):
+                vitals["inverter"]["split2_voltage"] = component_data["PINV_VSplit2"]
+            if isinstance(component_data.get("PINV_Fout"), (int, float)):
+                vitals["inverter"]["frequency"] = component_data["PINV_Fout"]
+            if isinstance(component_data.get("PINV_State"), str):
+                vitals["inverter"]["state"] = component_data["PINV_State"]
+
+        if component_name.startswith("TEPOD"):
+            if isinstance(component_data.get("POD_nom_energy_to_be_charged"), (int, float)):
+                vitals["pack"]["energy_to_charge"] = component_data["POD_nom_energy_to_be_charged"]
+            if isinstance(component_data.get("alerts"), list):
+                vitals["pack"]["alerts"] = [label for item in component_data["alerts"] if (label := normalize_alert_label(item)) is not None]
+
+        if component_name.startswith("TESYNC"):
+            if isinstance(component_data.get("ISLAND_GridConnected"), str):
+                vitals["sync"]["grid_connected"] = component_data["ISLAND_GridConnected"]
+            if isinstance(component_data.get("ISLAND_GridState"), str):
+                vitals["sync"]["grid_state"] = component_data["ISLAND_GridState"]
+
+    return vitals
+
+
+def normalize_alert_label(value) -> str | None:
+    if value in [None, ""]:
+        return None
+
+    label = str(value).strip()
+    if not label or label in IGNORED_ALERT_CODES:
+        return None
+    return label
+
+
+def summarize_names(values) -> str | None:
+    if not isinstance(values, list):
+        return None
+
+    labels = []
+    for value in values:
+        label = normalize_alert_label(value)
+        if label and label not in labels:
+            labels.append(label)
+
+    if not labels:
+        return None
+    if len(labels) <= 3:
+        return "; ".join(labels)
+    return f"{'; '.join(labels[:3])}; +{len(labels) - 3} more"
+
+
+def alert_object_has_meaningful_data(value: dict) -> bool:
+    if not isinstance(value, dict) or not value:
+        return False
+    if isinstance(value.get("grid_faults"), list) and value["grid_faults"]:
+        return True
+    if first_alert_value(value, ["description", "message", "decoded_alert", "name", "title", "alert_name", "code"]) is not None:
+        return True
+    return bool(active_mapping_keys(value))
+
+
+def alert_items(alerts, alerts_pw):
+    if isinstance(alerts_pw, dict) and alerts_pw:
+        if isinstance(alerts_pw.get("grid_faults"), list) and alerts_pw["grid_faults"]:
+            return alerts_pw["grid_faults"]
+        if alert_object_has_meaningful_data(alerts_pw):
+            return [alerts_pw]
+        return []
+    if isinstance(alerts, list):
+        return [label for alert in alerts if (label := normalize_alert_label(alert)) is not None]
+    return []
+
+
+def first_alert_value(alert: dict, keys: list[str]) -> str | None:
+    for key in keys:
+        value = alert.get(key)
+        if value not in [None, ""]:
+            return str(value)
+    return None
+
+
+def active_mapping_keys(value: dict) -> list[str]:
+    keys = []
+    for key, nested in value.items():
+        if key in IGNORED_ALERT_CODES:
+            continue
+        if nested in [1, True, "1", "true", "True", "active", "Active"]:
+            keys.append(str(key))
+    return keys
+
+
+def latest_alert(alerts):
+    if not isinstance(alerts, list) or not alerts:
+        return None
+
+    latest = alerts[0]
+    return latest if isinstance(latest, dict) else None
+
+
+def alert_summary(alerts, alerts_pw) -> str | None:
+    items = alert_items(alerts, alerts_pw)
+    if not items:
+        if isinstance(alerts, dict) and alerts:
+            active_keys = active_mapping_keys(alerts)
+            if active_keys:
+                return "; ".join(active_keys[:3]) if len(active_keys) <= 3 else f"{'; '.join(active_keys[:3])}; +{len(active_keys) - 3} more"
+        return None
+
+    latest = items[0]
+    if not isinstance(latest, dict):
+        return str(latest)
+
+    summary = first_alert_value(latest, ["description", "message", "decoded_alert", "name", "title", "alert_name", "code"])
+    if summary is not None:
+        return summary
+
+    active_keys = active_mapping_keys(latest)
+    if active_keys:
+        return "; ".join(active_keys[:3]) if len(active_keys) <= 3 else f"{'; '.join(active_keys[:3])}; +{len(active_keys) - 3} more"
+
+    return json.dumps(latest, sort_keys=True)
+
+
+def alert_code(alerts, alerts_pw) -> str | None:
+    if isinstance(alerts, dict) and alerts:
+        active_keys = active_mapping_keys(alerts)
+        if active_keys:
+            return active_keys[0]
+
+    items = alert_items(alerts, alerts_pw)
+    if items and not isinstance(items[0], dict):
+        return str(items[0])
+
+    latest = latest_alert(items)
+    if latest is None:
+        return None
+
+    return first_alert_value(latest, ["code", "alert_name", "name", "title"])
+
+
+def active_alerts_summary(alerts, alerts_pw) -> str | None:
+    items = alert_items(alerts, alerts_pw)
+    if not items:
+        if isinstance(alerts, dict) and alerts:
+            labels = active_mapping_keys(alerts)
+            if labels:
+                return "; ".join(labels[:3]) if len(labels) <= 3 else f"{'; '.join(labels[:3])}; +{len(labels) - 3} more"
+        return None
+
+    labels = []
+    for alert in items:
+        if isinstance(alert, dict):
+            label = first_alert_value(alert, ["description", "message", "decoded_alert", "name", "title", "alert_name", "code"])
+        else:
+            label = str(alert)
+        if label and label not in labels:
+            labels.append(label)
+
+    if not labels:
+        return None
+
+    if len(labels) <= 3:
+        return "; ".join(labels)
+
+    return f"{'; '.join(labels[:3])}; +{len(labels) - 3} more"
+
+
+def snapshot_is_ready(snapshot: dict) -> bool:
+    aggregates = snapshot.get("aggregates")
+    soe = snapshot.get("soe")
+
+    if not isinstance(aggregates, dict) or not aggregates:
+        return False
+    if not isinstance(soe, dict) or "percentage" not in soe:
+        return False
+
+    required_aggregate_sections = ["site", "load", "solar", "battery"]
+    return all(isinstance(aggregates.get(section), dict) for section in required_aggregate_sections)
+
+
+def snapshot_readiness_error(snapshot: dict) -> str:
+    aggregates = snapshot.get("aggregates")
+    soe = snapshot.get("soe")
+
+    if not isinstance(aggregates, dict) or not aggregates:
+        return "missing aggregates"
+    if not isinstance(soe, dict) or "percentage" not in soe:
+        return "missing soe.percentage"
+
+    missing_sections = [
+        section
+        for section in ["site", "load", "solar", "battery"]
+        if not isinstance(aggregates.get(section), dict)
+    ]
+    if missing_sections:
+        return f"missing aggregate sections: {', '.join(missing_sections)}"
+
+    return "unknown readiness failure"
+
+
+def _summary_fields(snapshot: dict, is_replayed: bool = False, error: str | None = None, duration_ms: int | None = None) -> dict:
+    aggregates = snapshot.get("aggregates") if isinstance(snapshot, dict) else {}
+    site = aggregates.get("site") if isinstance(aggregates, dict) else {}
+    load = aggregates.get("load") if isinstance(aggregates, dict) else {}
+    solar = aggregates.get("solar") if isinstance(aggregates, dict) else {}
+    battery = aggregates.get("battery") if isinstance(aggregates, dict) else {}
+
+    fields = {
+        "replayed": "yes" if is_replayed else "no",
+        "available_alerts": snapshot.get("alert_count", "n/a"),
+        "reserve": snapshot.get("reserve", "n/a"),
+        "soe": snapshot.get("soe", {}).get("percentage", "n/a") if isinstance(snapshot.get("soe"), dict) else "n/a",
+        "site": site.get("instant_power", "n/a") if isinstance(site, dict) else "n/a",
+        "load": load.get("instant_power", "n/a") if isinstance(load, dict) else "n/a",
+        "solar": solar.get("instant_power", "n/a") if isinstance(solar, dict) else "n/a",
+        "battery": battery.get("instant_power", "n/a") if isinstance(battery, dict) else "n/a",
+        "strings": len(snapshot.get("strings", {})) if isinstance(snapshot.get("strings"), dict) else 0,
+        "blocks": len(snapshot.get("battery_blocks", {})) if isinstance(snapshot.get("battery_blocks"), dict) else 0,
+    }
+    if duration_ms is not None:
+        fields["duration_ms"] = duration_ms
+    if error:
+        fields["error"] = error
+    return fields
+
+
+LAST_LOGGED_SUMMARY = {"snapshot": None, "time": 0.0}
+
+
+def log_publish_summary(snapshot: dict, is_replayed: bool = False, error: str | None = None, duration_ms: int | None = None) -> None:
+    fields = _summary_fields(snapshot, is_replayed=is_replayed, error=error, duration_ms=duration_ms)
+    snapshot_key = tuple((key, str(value)) for key, value in fields.items())
+    now = time.time()
+    should_log = LAST_LOGGED_SUMMARY["snapshot"] != snapshot_key
+
+    if not should_log and STATUS_LOG_INTERVAL_SECONDS > 0:
+        should_log = (now - LAST_LOGGED_SUMMARY["time"]) >= STATUS_LOG_INTERVAL_SECONDS
+
+    if not should_log:
+        return
+
+    LAST_LOGGED_SUMMARY["snapshot"] = snapshot_key
+    LAST_LOGGED_SUMMARY["time"] = now
+    timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    rendered_fields = [f"{key}={value}" for key, value in fields.items()]
+    print(f"{timestamp} mqtt publisher cycle: " + " ".join(rendered_fields), file=sys.stderr, flush=True)
+
+
+def build_snapshot(previous_snapshot: dict | None = None) -> dict:
+    previous_snapshot = previous_snapshot or {}
+
+    alerts = prefer_current_value(fetch_json("/alerts"), previous_snapshot.get("alerts"))
+    alerts_pw = prefer_current_value(fetch_json("/alerts/pw"), previous_snapshot.get("alerts_pw"))
+    battery_blocks = prefer_current_value(fetch_json("/pw/battery_blocks"), previous_snapshot.get("battery_blocks"))
+    reserve = prefer_current_value(normalize_reserve(fetch_json("/pw/get_reserve")), previous_snapshot.get("reserve"))
+    version = prefer_current_value(normalize_version(fetch_json("/version")), previous_snapshot.get("version"))
+    grid_status = prefer_current_value(normalize_grid_status(fetch_json("/pw/grid_status")), previous_snapshot.get("grid_status"))
+    mode = prefer_current_value(normalize_mode(fetch_json("/pw/get_mode")), previous_snapshot.get("mode"))
+    vitals = prefer_current_value(normalize_vitals(fetch_json("/vitals")), previous_snapshot.get("vitals"))
+    effective_alerts = alert_items(alerts, alerts_pw)
+    gateway_alerts = vitals.get("gateway", {}).get("alerts", []) if isinstance(vitals, dict) else []
+    pack_alerts = vitals.get("pack", {}).get("alerts", []) if isinstance(vitals, dict) else []
+
+    snapshot = {
+        "updated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "aggregates": prefer_current_value(fetch_json("/aggregates"), previous_snapshot.get("aggregates")),
+        "soe": prefer_current_value(fetch_json("/soe"), previous_snapshot.get("soe")),
+        "strings": prefer_current_value(fetch_json("/strings"), previous_snapshot.get("strings")),
+        "health": prefer_current_value(fetch_json("/health"), previous_snapshot.get("health")),
+        "version": version,
+        "grid_status": grid_status,
+        "reserve": reserve,
+        "mode": mode,
+        "alerts": alerts,
+        "alerts_pw": alerts_pw if isinstance(alerts_pw, dict) else previous_snapshot.get("alerts_pw", {}),
+        "alert_count": len(effective_alerts),
+        "active_alerts_summary": prefer_current_value(active_alerts_summary(alerts, alerts_pw), previous_snapshot.get("active_alerts_summary")),
+        "gateway_alert_count": len(gateway_alerts),
+        "gateway_alerts_summary": prefer_current_value(summarize_names(gateway_alerts), previous_snapshot.get("gateway_alerts_summary")),
+        "pack_alert_count": len(pack_alerts),
+        "pack_alerts_summary": prefer_current_value(summarize_names(pack_alerts), previous_snapshot.get("pack_alerts_summary")),
+        "battery_blocks": battery_blocks,
+        "battery_block_count": len(battery_blocks) if isinstance(battery_blocks, dict) else previous_snapshot.get("battery_block_count", 0),
+        "vitals": vitals if isinstance(vitals, dict) else previous_snapshot.get("vitals", {}),
+    }
+
+    return snapshot
+
+
+def main() -> int:
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id=MQTT_CLIENT_ID)
+    if MQTT_USERNAME:
+        client.username_pw_set(MQTT_USERNAME, MQTT_PASSWORD)
+    client.connect(MQTT_HOST, MQTT_PORT, 60)
+    client.loop_start()
+
+    stop = {"value": False}
+
+    def handle_signal(signum, frame):
+        del signum, frame
+        stop["value"] = True
+
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
+    for entity in DEPRECATED_DISCOVERY_ENTITIES:
+        clear_discovery(client, entity["component"], entity["object_id"])
+
+    for definition in STATIC_SENSORS:
+        publish_discovery(client, definition)
+
+    published_string_keys = set()
+    published_battery_block_keys = set()
+    consecutive_failures = 0
+    is_available = False
+    last_snapshot = None
+
+    while not stop["value"]:
+        cycle_started_at = time.monotonic()
+        try:
+            snapshot = build_snapshot(last_snapshot)
+            if not snapshot_is_ready(snapshot):
+                raise RuntimeError(f"core proxy data unavailable: {snapshot_readiness_error(snapshot)}")
+
+            last_snapshot = snapshot
+            string_keys = set(snapshot.get("strings", {}).keys())
+            for string_name in sorted(string_keys - published_string_keys):
+                publish_string_discovery(client, string_name)
+            published_string_keys = string_keys
+
+            battery_block_keys = set(snapshot.get("battery_blocks", {}).keys())
+            for block_name in sorted(battery_block_keys - published_battery_block_keys):
+                publish_battery_block_discovery(client, block_name)
+            published_battery_block_keys = battery_block_keys
+
+            consecutive_failures = 0
+
+            client.publish(STATE_TOPIC, json.dumps(snapshot), retain=MQTT_RETAIN)
+            duration_ms = int((time.monotonic() - cycle_started_at) * 1000)
+            log_publish_summary(snapshot, duration_ms=duration_ms)
+            if not is_available:
+                client.publish(AVAILABILITY_TOPIC, "online", retain=True)
+                is_available = True
+        except Exception as exc:
+            duration_ms = int((time.monotonic() - cycle_started_at) * 1000)
+            consecutive_failures += 1
+            print(
+                f"mqtt publisher error ({consecutive_failures}/{FAILURES_BEFORE_OFFLINE}): {exc}",
+                file=sys.stderr,
+                flush=True,
+            )
+            print(traceback.format_exc(), file=sys.stderr, flush=True)
+            if last_snapshot is not None:
+                client.publish(STATE_TOPIC, json.dumps(last_snapshot), retain=MQTT_RETAIN)
+                log_publish_summary(last_snapshot, is_replayed=True, error=str(exc), duration_ms=duration_ms)
+            if consecutive_failures >= FAILURES_BEFORE_OFFLINE and is_available:
+                client.publish(AVAILABILITY_TOPIC, "offline", retain=True)
+                is_available = False
+        time.sleep(PUBLISH_INTERVAL)
+
+    if is_available:
+        client.publish(AVAILABILITY_TOPIC, "offline", retain=True)
+    client.loop_stop()
+    client.disconnect()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/modules/proxmox/powerwall-bridge/templates/powerwall-mqtt-publisher.service.tftpl
+++ b/modules/proxmox/powerwall-bridge/templates/powerwall-mqtt-publisher.service.tftpl
@@ -1,0 +1,17 @@
+[Unit]
+Description=Powerwall MQTT publisher for Home Assistant
+After=network-online.target powerwall-proxy.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=${env_file}
+Environment=PYTHONUNBUFFERED=1
+StandardOutput=append:/var/log/powerwall-mqtt-publisher.log
+StandardError=append:/var/log/powerwall-mqtt-publisher.log
+ExecStart=/opt/powerwall-bridge/venv/bin/python ${publisher_path}
+Restart=on-failure
+RestartSec=10s
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/proxmox/powerwall-bridge/templates/powerwall-mqtt.env.tftpl
+++ b/modules/proxmox/powerwall-bridge/templates/powerwall-mqtt.env.tftpl
@@ -1,0 +1,19 @@
+PROXY_URL=http://127.0.0.1:${proxy_port}
+MQTT_HOST=${mqtt_host}
+MQTT_PORT=${mqtt_port}
+MQTT_TOPIC_PREFIX=${mqtt_topic_prefix}
+MQTT_DISCOVERY_PREFIX=${mqtt_discovery_prefix}
+MQTT_CLIENT_ID=${mqtt_client_id}
+MQTT_RETAIN=${tostring(mqtt_retain)}
+MQTT_PUBLISH_INTERVAL_SECONDS=${mqtt_publish_interval_seconds}
+MQTT_STATUS_LOG_INTERVAL_SECONDS=${mqtt_status_log_interval_seconds}
+MQTT_FAILURES_BEFORE_OFFLINE=${mqtt_failures_before_offline}
+MQTT_FETCH_TIMEOUT_SECONDS=${mqtt_fetch_timeout_seconds}
+MQTT_FETCH_RETRIES=${mqtt_fetch_retries}
+MQTT_FETCH_RETRY_DELAY_SECONDS=${mqtt_fetch_retry_delay_seconds}
+DEVICE_ID=${device_id}
+DEVICE_NAME=${device_name}
+%{ if mqtt_credentials != null ~}
+MQTT_USERNAME=${mqtt_credentials.username}
+MQTT_PASSWORD=${mqtt_credentials.password}
+%{ endif ~}

--- a/modules/proxmox/powerwall-bridge/templates/powerwall-proxy.env.tftpl
+++ b/modules/proxmox/powerwall-bridge/templates/powerwall-proxy.env.tftpl
@@ -1,0 +1,31 @@
+TZ=${timezone}
+PW_BIND_ADDRESS=${proxy_bind_address}
+PW_PORT=${proxy_port}
+PW_HTTPS=${proxy_https_mode}
+PW_CACHE_EXPIRE=${proxy_cache_expire}
+PW_CACHE_TTL=${proxy_cache_ttl}
+PW_TIMEOUT=${proxy_timeout}
+PW_POOL_MAXSIZE=${proxy_pool_maxsize}
+PW_FAIL_FAST=${tostring(proxy_fail_fast)}
+PW_GRACEFUL_DEGRADATION=${tostring(proxy_graceful_degradation)}
+PW_HEALTH_CHECK=${tostring(proxy_health_check)}
+PW_SUPPRESS_NETWORK_ERRORS=${tostring(proxy_suppress_network_errors)}
+PW_NETWORK_ERROR_RATE_LIMIT=${proxy_network_error_rate_limit}
+PW_TIMEZONE=${timezone}
+PW_AUTH_PATH=/var/lib/powerwall-bridge
+PW_HOST=${powerwall_host}
+%{ if powerwall_gateway_password != null ~}
+PW_GW_PWD=${powerwall_gateway_password}
+%{ endif ~}
+%{ if powerwall_customer_password != null ~}
+PW_PASSWORD=${powerwall_customer_password}
+%{ endif ~}
+%{ if powerwall_email != null ~}
+PW_EMAIL=${powerwall_email}
+%{ endif ~}
+%{ if powerwall_wifi_host != null ~}
+PW_WIFI_HOST=${powerwall_wifi_host}
+%{ endif ~}
+%{ if write_rsa_key ~}
+PW_RSA_KEY_PATH=${rsa_key_path}
+%{ endif ~}

--- a/modules/proxmox/powerwall-bridge/templates/powerwall-proxy.service.tftpl
+++ b/modules/proxmox/powerwall-bridge/templates/powerwall-proxy.service.tftpl
@@ -1,0 +1,18 @@
+[Unit]
+Description=pyPowerwall proxy
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/powerwall-bridge/src/proxy
+EnvironmentFile=${env_file}
+Environment=PYTHONUNBUFFERED=1
+StandardOutput=append:/var/log/powerwall-proxy.log
+StandardError=append:/var/log/powerwall-proxy.log
+ExecStart=/opt/powerwall-bridge/venv/bin/python /opt/powerwall-bridge/src/proxy/server.py
+Restart=on-failure
+RestartSec=10s
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/proxmox/powerwall-bridge/templates/powerwall-route.service.tftpl
+++ b/modules/proxmox/powerwall-bridge/templates/powerwall-route.service.tftpl
@@ -1,0 +1,13 @@
+[Unit]
+Description=Powerwall TEDAPI route
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh -lc 'ip route replace ${destination} via ${gateway} dev ${interface}%{ if onlink } onlink%{ endif }'
+ExecStop=/bin/sh -lc 'ip route del ${destination} via ${gateway} dev ${interface}%{ if onlink } onlink%{ endif } || true'
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/proxmox/powerwall-bridge/variables.tf
+++ b/modules/proxmox/powerwall-bridge/variables.tf
@@ -1,0 +1,591 @@
+variable "name" {
+  description = "Hostname assigned to the Powerwall bridge container."
+  type        = string
+}
+
+variable "node_name" {
+  description = "Proxmox node that hosts the Powerwall bridge container."
+  type        = string
+}
+
+variable "ipv4_address" {
+  description = "IPv4 address for the bridge container. Use `dhcp` for DHCP or provide a static address in CIDR notation."
+  type        = string
+  default     = "dhcp"
+}
+
+variable "gateway" {
+  description = "Optional IPv4 gateway for the bridge container."
+  type        = string
+  default     = null
+}
+
+variable "vm_id" {
+  description = "Optional static Proxmox VMID for the bridge container."
+  type        = number
+  default     = null
+}
+
+variable "description" {
+  description = "Optional description shown in the Proxmox UI."
+  type        = string
+  default     = null
+}
+
+variable "bridge" {
+  description = "Proxmox bridge attached to the bridge container NIC."
+  type        = string
+  default     = "vmbr0"
+}
+
+variable "vlan_id" {
+  description = "Optional VLAN tag for the bridge container NIC."
+  type        = number
+  default     = null
+}
+
+variable "mac_address" {
+  description = "Optional MAC address for the bridge container NIC."
+  type        = string
+  default     = null
+}
+
+variable "mtu" {
+  description = "Optional MTU for the bridge container NIC."
+  type        = number
+  default     = null
+}
+
+variable "firewall" {
+  description = "Whether to enable the Proxmox firewall flag on the container NIC."
+  type        = bool
+  default     = false
+}
+
+variable "rate_limit" {
+  description = "Optional egress rate limit for the bridge container NIC in MiB/s."
+  type        = number
+  default     = null
+}
+
+variable "datastore_id" {
+  description = "Datastore used for the bridge container root filesystem."
+  type        = string
+  default     = "local-lvm"
+}
+
+variable "disk_size_gb" {
+  description = "Root filesystem size in gigabytes."
+  type        = number
+  default     = 8
+}
+
+variable "cpu_cores" {
+  description = "Number of CPU cores assigned to the bridge container."
+  type        = number
+  default     = 2
+}
+
+variable "cpu_units" {
+  description = "Proxmox CPU shares for the bridge container."
+  type        = number
+  default     = 1024
+}
+
+variable "cpu_limit" {
+  description = "CPU limit for the bridge container. Set to 0 for no hard cap."
+  type        = number
+  default     = 0
+}
+
+variable "memory_mb" {
+  description = "Dedicated memory for the bridge container in megabytes."
+  type        = number
+  default     = 1024
+}
+
+variable "swap_mb" {
+  description = "Swap allocation for the bridge container in megabytes."
+  type        = number
+  default     = 512
+}
+
+variable "tags" {
+  description = "Tags applied to the bridge container."
+  type        = list(string)
+  default     = ["powerwall", "bridge", "mqtt", "home-assistant", "proxmox"]
+}
+
+variable "protection" {
+  description = "Whether Proxmox protection should be enabled for the bridge container."
+  type        = bool
+  default     = false
+}
+
+variable "startup_order" {
+  description = "Proxmox startup order for the bridge container."
+  type        = number
+  default     = 25
+}
+
+variable "startup_up_delay" {
+  description = "Delay in seconds before the next guest starts after this container."
+  type        = number
+  default     = 10
+}
+
+variable "startup_down_delay" {
+  description = "Delay in seconds before the next guest stops after this container."
+  type        = number
+  default     = 10
+}
+
+variable "started" {
+  description = "Whether the container should be started after creation."
+  type        = bool
+  default     = true
+}
+
+variable "start_on_boot" {
+  description = "Whether the container should start automatically when the host boots."
+  type        = bool
+  default     = true
+}
+
+variable "unprivileged" {
+  description = "Whether the bridge container should run unprivileged."
+  type        = bool
+  default     = false
+}
+
+variable "nesting" {
+  description = "Whether container nesting should be enabled."
+  type        = bool
+  default     = false
+}
+
+variable "keyctl" {
+  description = "Whether keyctl support should be enabled inside the container."
+  type        = bool
+  default     = true
+}
+
+variable "network_interface_name" {
+  description = "Interface name configured inside the container."
+  type        = string
+  default     = "eth0"
+}
+
+variable "dns" {
+  description = "Optional DNS settings applied during container initialization."
+  type = object({
+    domain  = optional(string)
+    servers = optional(list(string))
+  })
+  default = null
+}
+
+variable "root_public_keys" {
+  description = "SSH public keys installed for the root account inside the bridge container."
+  type        = list(string)
+  default     = []
+}
+
+variable "root_password" {
+  description = "Optional root password for the bridge container. Prefer SSH keys when possible."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "container_template" {
+  description = "Container template reference. Provide either file_id for an existing template or url to download on the target node."
+  type = object({
+    file_id            = optional(string)
+    url                = optional(string)
+    datastore_id       = optional(string)
+    checksum           = optional(string)
+    checksum_algorithm = optional(string)
+    overwrite          = optional(bool)
+    type               = optional(string)
+  })
+
+  validation {
+    condition = (
+      try(var.container_template.file_id, null) != null && try(var.container_template.url, null) == null
+      ) || (
+      try(var.container_template.file_id, null) == null && try(var.container_template.url, null) != null
+    )
+    error_message = "container_template must define exactly one of file_id or url."
+  }
+}
+
+variable "snippet_datastore_id" {
+  description = "Datastore that allows snippet content for hook scripts. Usually a directory-backed storage such as local."
+  type        = string
+  default     = "local"
+}
+
+variable "packages" {
+  description = "Base OS packages installed inside the bridge container."
+  type        = list(string)
+  default = [
+    "bash",
+    "ca-certificates",
+    "curl",
+    "git",
+    "iproute2",
+    "python3",
+    "python3-pip",
+    "python3-venv",
+  ]
+}
+
+variable "timezone" {
+  description = "Timezone used by pyPowerwall and the MQTT publisher."
+  type        = string
+  default     = "UTC"
+
+  validation {
+    condition     = trimspace(var.timezone) != ""
+    error_message = "timezone must not be empty."
+  }
+}
+
+variable "pypowerwall_repo_ref" {
+  description = "Git ref used when bootstrapping the upstream pyPowerwall repository inside the container."
+  type        = string
+  default     = "2edc813d503bacfb1fd5033ea0499bb238530bf3"
+}
+
+variable "powerwall" {
+  description = "Connectivity and credential settings passed into pyPowerwall. For Powerwall 3 string metrics, set gw_password and use host 192.168.91.1 for Wi-Fi TEDAPI or the vendor-subnet IP for v1r LAN mode."
+  type = object({
+    host            = optional(string)
+    gw_password     = optional(string)
+    password        = optional(string)
+    email           = optional(string)
+    wifi_host       = optional(string)
+    rsa_key_content = optional(string)
+  })
+  default   = {}
+  sensitive = true
+
+  validation {
+    condition = (
+      try(var.powerwall.rsa_key_content, null) == null || try(var.powerwall.gw_password, null) != null
+    )
+    error_message = "powerwall.gw_password must be set when powerwall.rsa_key_content is provided."
+  }
+
+  validation {
+    condition = (
+      try(var.powerwall.host, null) != null ||
+      try(var.powerwall.email, null) != null ||
+      try(var.powerwall.wifi_host, null) != null ||
+      try(var.powerwall.gw_password, null) != null ||
+      try(var.powerwall.password, null) != null ||
+      try(var.powerwall.rsa_key_content, null) != null
+    )
+    error_message = "powerwall must define enough connection information for pyPowerwall, such as host, email, gw_password, password, wifi_host, or rsa_key_content."
+  }
+
+  validation {
+    condition = alltrue([
+      for value in [
+        try(var.powerwall.host, null),
+        try(var.powerwall.gw_password, null),
+        try(var.powerwall.password, null),
+        try(var.powerwall.email, null),
+        try(var.powerwall.wifi_host, null),
+        try(var.powerwall.rsa_key_content, null),
+      ] : value == null ? true : trimspace(value) != ""
+    ])
+    error_message = "powerwall fields must be null or non-empty strings."
+  }
+}
+
+variable "route_to_powerwall" {
+  description = "Optional persistent route added inside the container for TEDAPI access. In the normal design this should point to the pve3 host IP as the next hop from inside the LXC. The destination defaults to 192.168.91.1/32 and the interface defaults to the container NIC, so gateway is usually the only input you need."
+  type = object({
+    gateway     = string
+    destination = optional(string)
+    interface   = optional(string)
+    onlink      = optional(bool)
+  })
+  default = null
+
+  validation {
+    condition = (
+      var.route_to_powerwall == null ||
+      (!strcontains(var.route_to_powerwall.gateway, "/") && trimspace(var.route_to_powerwall.gateway) != "")
+    )
+    error_message = "route_to_powerwall.gateway must be a non-empty IP address without CIDR notation."
+  }
+}
+
+variable "proxy_bind_address" {
+  description = "Bind address for the pyPowerwall proxy HTTP server."
+  type        = string
+  default     = "0.0.0.0"
+}
+
+variable "proxy_port" {
+  description = "Port exposed by the pyPowerwall proxy."
+  type        = number
+  default     = 8675
+
+  validation {
+    condition     = var.proxy_port > 0 && var.proxy_port < 65536
+    error_message = "proxy_port must be a valid TCP port."
+  }
+}
+
+variable "proxy_https_mode" {
+  description = "pyPowerwall proxy HTTPS mode: no, http, or yes."
+  type        = string
+  default     = "no"
+
+  validation {
+    condition     = contains(["no", "http", "yes"], var.proxy_https_mode)
+    error_message = "proxy_https_mode must be one of: no, http, yes."
+  }
+}
+
+variable "proxy_cache_expire" {
+  description = "pyPowerwall cache expiration in seconds."
+  type        = number
+  default     = 5
+
+  validation {
+    condition     = var.proxy_cache_expire > 0
+    error_message = "proxy_cache_expire must be greater than 0."
+  }
+}
+
+variable "proxy_cache_ttl" {
+  description = "Maximum age in seconds for degraded cached responses before the proxy returns null."
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = var.proxy_cache_ttl > 0
+    error_message = "proxy_cache_ttl must be greater than 0."
+  }
+}
+
+variable "proxy_timeout" {
+  description = "Timeout in seconds for pyPowerwall network calls."
+  type        = number
+  default     = 5
+
+  validation {
+    condition     = var.proxy_timeout > 0
+    error_message = "proxy_timeout must be greater than 0."
+  }
+}
+
+variable "proxy_pool_maxsize" {
+  description = "Maximum concurrent upstream connections used by pyPowerwall."
+  type        = number
+  default     = 15
+
+  validation {
+    condition     = var.proxy_pool_maxsize > 0
+    error_message = "proxy_pool_maxsize must be greater than 0."
+  }
+}
+
+variable "proxy_fail_fast" {
+  description = "Whether the proxy should fail fast when the connection is degraded."
+  type        = bool
+  default     = false
+}
+
+variable "proxy_graceful_degradation" {
+  description = "Whether the proxy should serve recent cached data during transient failures."
+  type        = bool
+  default     = true
+}
+
+variable "proxy_health_check" {
+  description = "Whether the proxy should track connection health."
+  type        = bool
+  default     = true
+}
+
+variable "proxy_suppress_network_errors" {
+  description = "Whether to suppress individual network error lines in the proxy logs."
+  type        = bool
+  default     = true
+}
+
+variable "proxy_network_error_rate_limit" {
+  description = "Maximum network error messages per minute per proxy function when suppression is disabled."
+  type        = number
+  default     = 5
+
+  validation {
+    condition     = var.proxy_network_error_rate_limit >= 0
+    error_message = "proxy_network_error_rate_limit must be 0 or greater."
+  }
+}
+
+variable "enable_proxy_service" {
+  description = "Whether to enable and start the pyPowerwall proxy service."
+  type        = bool
+  default     = true
+}
+
+variable "enable_mqtt_publisher" {
+  description = "Whether to enable the MQTT publisher service when mqtt is configured."
+  type        = bool
+  default     = true
+}
+
+variable "mqtt_publish_interval_seconds" {
+  description = "Publish interval in seconds for MQTT snapshots."
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = var.mqtt_publish_interval_seconds > 0
+    error_message = "mqtt_publish_interval_seconds must be greater than 0."
+  }
+}
+
+variable "mqtt_status_log_interval_seconds" {
+  description = "Heartbeat interval in seconds for unchanged MQTT publisher status logs. Set to 0 to log only on status changes and errors."
+  type        = number
+  default     = 900
+
+  validation {
+    condition     = var.mqtt_status_log_interval_seconds >= 0
+    error_message = "mqtt_status_log_interval_seconds must be 0 or greater."
+  }
+}
+
+variable "mqtt_failures_before_offline" {
+  description = "Number of consecutive failed publisher cycles before the MQTT bridge marks itself offline."
+  type        = number
+  default     = 5
+
+  validation {
+    condition     = var.mqtt_failures_before_offline > 0
+    error_message = "mqtt_failures_before_offline must be greater than 0."
+  }
+}
+
+variable "mqtt_fetch_timeout_seconds" {
+  description = "Timeout in seconds for each HTTP request from the MQTT publisher to the local pyPowerwall proxy."
+  type        = number
+  default     = 15
+
+  validation {
+    condition     = var.mqtt_fetch_timeout_seconds > 0
+    error_message = "mqtt_fetch_timeout_seconds must be greater than 0."
+  }
+}
+
+variable "mqtt_fetch_retries" {
+  description = "Number of retry attempts per endpoint fetch before the MQTT publisher gives up for that cycle."
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.mqtt_fetch_retries >= 0
+    error_message = "mqtt_fetch_retries must be 0 or greater."
+  }
+}
+
+variable "mqtt_fetch_retry_delay_seconds" {
+  description = "Delay in seconds between MQTT publisher fetch retries."
+  type        = number
+  default     = 1.5
+
+  validation {
+    condition     = var.mqtt_fetch_retry_delay_seconds >= 0
+    error_message = "mqtt_fetch_retry_delay_seconds must be 0 or greater."
+  }
+}
+
+variable "mqtt" {
+  description = "Optional MQTT broker settings used for Home Assistant auto-discovery and state publishing."
+  type = object({
+    host             = string
+    port             = optional(number)
+    topic_prefix     = optional(string)
+    discovery_prefix = optional(string)
+    client_id        = optional(string)
+    retain           = optional(bool)
+  })
+  default = null
+
+  validation {
+    condition = (
+      var.mqtt == null || (
+        trimspace(var.mqtt.host) != "" &&
+        coalesce(try(var.mqtt.port, null), 1883) > 0 &&
+        coalesce(try(var.mqtt.port, null), 1883) < 65536 &&
+        (try(var.mqtt.topic_prefix, null) == null || trimspace(var.mqtt.topic_prefix) != "") &&
+        (try(var.mqtt.discovery_prefix, null) == null || trimspace(var.mqtt.discovery_prefix) != "")
+      )
+    )
+    error_message = "mqtt.host must be non-empty, mqtt.port must be a valid TCP port, and mqtt.topic_prefix and mqtt.discovery_prefix cannot be empty strings when provided."
+  }
+}
+
+variable "mqtt_credentials" {
+  description = "Optional MQTT authentication settings."
+  type = object({
+    username = string
+    password = string
+  })
+  default   = null
+  sensitive = true
+
+  validation {
+    condition = (
+      var.mqtt_credentials == null || (
+        trimspace(var.mqtt_credentials.username) != "" &&
+        trimspace(var.mqtt_credentials.password) != ""
+      )
+    )
+    error_message = "mqtt_credentials.username and mqtt_credentials.password must be non-empty when mqtt_credentials is provided."
+  }
+}
+
+variable "pve_connection" {
+  description = "Connection info for the target Proxmox environment used by Terraform itself."
+  type = object({
+    api_user         = string
+    api_password     = optional(string, null)
+    api_token_id     = optional(string, null)
+    api_token_secret = optional(string, null)
+    endpoint         = string
+    tls_insecure     = optional(bool, false)
+  })
+
+  validation {
+    condition = (
+      trimspace(var.pve_connection.endpoint) != "" &&
+      trimspace(var.pve_connection.api_user) != ""
+    )
+    error_message = "pve_connection.endpoint and pve_connection.api_user must be non-empty."
+  }
+
+  validation {
+    condition = (
+      (
+        var.pve_connection.api_password != null &&
+        var.pve_connection.api_token_id == null &&
+        var.pve_connection.api_token_secret == null
+        ) || (
+        var.pve_connection.api_password == null &&
+        var.pve_connection.api_token_id != null &&
+        var.pve_connection.api_token_secret != null
+      )
+    )
+    error_message = "pve_connection must use exactly one authentication method: either api_password, or api_token_id plus api_token_secret."
+  }
+}

--- a/modules/proxmox/powerwall-bridge/versions.tf
+++ b/modules/proxmox/powerwall-bridge/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = ">= 0.103.0"
+    }
+  }
+}
+
+provider "proxmox" {
+  endpoint = trimspace(var.pve_connection.endpoint)
+  insecure = var.pve_connection.tls_insecure
+
+  username = var.pve_connection.api_user
+  password = var.pve_connection.api_password
+  api_token = (
+    var.pve_connection.api_token_id != null &&
+    var.pve_connection.api_token_secret != null
+  ) ? format("%s=%s", var.pve_connection.api_token_id, var.pve_connection.api_token_secret) : null
+}


### PR DESCRIPTION
Adds a Proxmox LXC module for running the pyPowerwall proxy with optional MQTT publishing for Home Assistant.

Includes:
- the new `proxmox/powerwall-bridge` module
- an example configuration
- README notes for host-side routing requirements and module usage

Validated with `terraform validate` for the module.