### PR TITLE
Fix API load balancer failover health check

### DIFF
--- a/modules/proxmox/k8s-api-lb/README.md
+++ b/modules/proxmox/k8s-api-lb/README.md
@@ -13,6 +13,7 @@ Internally it composes the sibling `../lxc` module so the base Proxmox LXC behav
 - Renders HAProxy and Keepalived configuration from Terraform templates.
 - Bootstraps packages and configuration through a Proxmox hook script.
 - Installs a container-safe HAProxy systemd unit so the service starts reliably inside LXC.
+- Tracks local HAProxy API readiness from Keepalived so the VIP fails over when HAProxy cannot serve the Kubernetes API.
 - Can optionally expose the Talos API on the same VIP through HAProxy port `50000`.
 
 ## Example
@@ -99,6 +100,7 @@ module "k8s_api_lb" {
 - Proxmox API TLS verification is enabled by default. Set `pve_connection.tls_insecure = true` only if your environment requires it.
 - When `container_template.file_id` is not supplied, the module downloads the template to each Proxmox node referenced by `instances`.
 - The first container boot is handled by a Proxmox hook script. Package auto-start is explicitly suppressed during bootstrap so the packaged HAProxy unit does not race the container-safe replacement unit.
+- Keepalived tracks `https://127.0.0.1:<haproxy_frontend_port>/readyz` through the local HAProxy frontend instead of only checking that the HAProxy process is running. HTTP responses such as Kubernetes' unauthenticated `401` count as healthy because they prove HAProxy reached an API backend.
 - This module owns the `proxmox` provider configuration so it can safely iterate the child `lxc` module with `for_each`. Keep that provider configuration at this level or above when calling it from Terragrunt.
 
 ## Inputs

--- a/modules/proxmox/k8s-api-lb/locals.tf
+++ b/modules/proxmox/k8s-api-lb/locals.tf
@@ -95,6 +95,7 @@ locals {
     for key, inst in local.instances : key => templatefile("${path.module}/templates/bootstrap.sh.tftpl", {
       haproxy_service    = var.haproxy_service_name
       keepalived_service = var.keepalived_service_name
+      frontend_port      = var.haproxy_frontend_port
       haproxy_config     = local.haproxy_configs[key]
       keepalived_config  = local.keepalived_configs[key]
     })

--- a/modules/proxmox/k8s-api-lb/templates/bootstrap.sh.tftpl
+++ b/modules/proxmox/k8s-api-lb/templates/bootstrap.sh.tftpl
@@ -23,7 +23,7 @@ package_installed() {
   dpkg-query -W -f='$${Status}' "$1" 2>/dev/null | grep -q 'install ok installed'
 }
 
-if ! package_installed haproxy || ! package_installed keepalived; then
+if ! package_installed haproxy || ! package_installed keepalived || ! package_installed curl; then
   if [ ! -e "$${policy_rc_d_path}" ]; then
     cat <<'POLICY_RC_D_EOF' >"$${policy_rc_d_path}"
 #!/bin/sh
@@ -34,10 +34,10 @@ POLICY_RC_D_EOF
   fi
 
   apt-get update
-  apt-get install -y --no-install-recommends haproxy keepalived
+  apt-get install -y --no-install-recommends haproxy keepalived curl
 fi
 
-install -d -m 0755 /etc/haproxy /etc/keepalived
+install -d -m 0755 /etc/haproxy /etc/keepalived /usr/local/sbin
 
 cat <<'HAPROXY_EOF' >/etc/haproxy/haproxy.cfg
 ${haproxy_config}
@@ -46,6 +46,25 @@ HAPROXY_EOF
 cat <<'KEEPALIVED_EOF' >/etc/keepalived/keepalived.conf
 ${keepalived_config}
 KEEPALIVED_EOF
+
+cat <<'HEALTH_CHECK_EOF' >/usr/local/sbin/k8s-api-lb-health-check.sh
+#!/bin/sh
+set -eu
+
+url="https://127.0.0.1:${frontend_port}/readyz"
+attempt=1
+
+while [ "$attempt" -le 3 ]; do
+  if /usr/bin/curl -k -sS --connect-timeout 1 --max-time 3 -o /dev/null "$url"; then
+    exit 0
+  fi
+
+  attempt=$((attempt + 1))
+  sleep 1
+done
+
+exit 1
+HEALTH_CHECK_EOF
 
 cat <<'HAPROXY_UNIT_EOF' >"/etc/systemd/system/$${haproxy_unit}"
 [Unit]
@@ -65,6 +84,7 @@ WantedBy=multi-user.target
 HAPROXY_UNIT_EOF
 
 chmod 0644 /etc/haproxy/haproxy.cfg /etc/keepalived/keepalived.conf "/etc/systemd/system/$${haproxy_unit}"
+chmod 0755 /usr/local/sbin/k8s-api-lb-health-check.sh
 
 systemctl daemon-reload
 systemctl reset-failed ${haproxy_service} ${keepalived_service} || true

--- a/modules/proxmox/k8s-api-lb/templates/keepalived.conf.tftpl
+++ b/modules/proxmox/k8s-api-lb/templates/keepalived.conf.tftpl
@@ -4,7 +4,7 @@ global_defs {
 }
 
 vrrp_script chk_haproxy {
-    script "/usr/bin/systemctl is-active --quiet ${haproxy_service}"
+    script "/usr/local/sbin/k8s-api-lb-health-check.sh"
     user root
     interval 2
     fall 2


### PR DESCRIPTION
## Summary

Fixes the Kubernetes API load balancer failover check so keepalived tracks whether the local HAProxy frontend can actually reach the API, not just whether the HAProxy process is running.

## Background

During a control-plane shutdown, one LB container kept the VIP even though its HAProxy frontend was accepting TCP connections and then closing during TLS. The other LB containers and the remaining control-plane API servers were healthy, but clients using the VIP could not connect because keepalived only checked `systemctl is-active haproxy`.

## Changes

- Install `curl` in the LB containers.
- Render `/usr/local/sbin/k8s-api-lb-health-check.sh` during bootstrap.
- Check `https://127.0.0.1:<frontend-port>/readyz` through the local HAProxy frontend.
- Update keepalived to track the local readiness script instead of only HAProxy service state.
- Document the new readiness behavior.

## Validation

- `terraform fmt -check`
- `terraform init -backend=false -input=false`
- `terraform validate`
- `git diff --check -- modules/proxmox/k8s-api-lb`
- Deployed to the cluster and repeated the control-plane shutdown test. The VIP stayed usable while the backend dropped out, and etcd quorum remained healthy on the surviving control-plane nodes.
