### PR TITLE
vm: stop cloud-init user_data edits from replacing the VM

### DIFF
--- a/modules/proxmox/vm/main.tf
+++ b/modules/proxmox/vm/main.tf
@@ -191,4 +191,27 @@ resource "proxmox_virtual_environment_vm" "this" {
   }
 
   tags = var.tags
+
+  # Editing cloud-init user_data force-replaces proxmox_virtual_environment_file
+  # (source_raw.data is ForceNew), which makes user_data_file_id "(known after
+  # apply)" and cascades into replacing this VM. That cascade is a phantom: the
+  # snippet's file name is deterministic and overwrite = true, so the resulting
+  # id string is byte-identical before and after — Terraform just can't prove it
+  # at plan time. The snippet is still rewritten on the host, so a rebuilt VM
+  # picks up the new config; a running one keeps its disk, which is what you
+  # want given cloud-init only runs at first boot anyway.
+  #
+  # Caveat: if you change cloud_init.user_data_name the id genuinely changes and
+  # is now ignored — use `terraform apply -replace` for that.
+  #
+  # This is deliberately not opt-in: ignore_changes takes a static list only, and
+  # the count-duplication workaround puts the two variants at different state
+  # addresses, so toggling the flag would plan a destroy+create of the VM rather
+  # than an attribute change. Consumers who do want a rebuild can run
+  # `terraform apply -replace=...` instead.
+  lifecycle {
+    ignore_changes = [
+      initialization[0].user_data_file_id,
+    ]
+  }
 }


### PR DESCRIPTION
## Problem

Editing `cloud_init.user_data` force-replaces `proxmox_virtual_environment_file.cloud_init_user` (`source_raw.data` is ForceNew). That makes `initialization.user_data_file_id` `(known after apply)`, which cascades into replacing `proxmox_virtual_environment_vm.this`.

Net effect: a one-line machine-config edit plans a **destroy/recreate of a running VM**.

## Why ignoring it is safe

The cascade is a phantom. The snippet's file name is deterministic and `overwrite = true`:

```hcl
file_name = format("%s-user-data.yaml", local.sanitized_name)
```

so the id (`local:snippets/<name>-user-data.yaml`) is byte-identical before and after the replacement — Terraform simply can't prove that at plan time. Ignoring the attribute drops a diff that was never real.

The snippet is still rewritten on the host, so a **rebuilt** VM picks up the new config, while a **running** one keeps its disk. That's correct either way, since cloud-init only runs at first boot.

## Why it isn't a variable

`ignore_changes` accepts a static list only. The `count`-duplication workaround puts the two variants at different state addresses, so toggling the flag would plan a destroy+create of the VM rather than an attribute change — and `moved` blocks can't be conditional either, so every toggle would need a hand-written `terraform state mv`. A toggle would be more dangerous than no toggle.

Consumers who genuinely want a rebuild have a CLI escape hatch:

```bash
terraform apply -replace='module.proxmox_vm["node"].proxmox_virtual_environment_vm.this'
```

## Caveat

Changing `cloud_init.user_data_name` produces a genuine id change that is now ignored; use `-replace` for that. Noted in the code comment.

## Verification

Against a live 3-node Talos cluster, planning a machine-config change:

| | Plan |
|---|---|
| before | `6 to add, 0 to change, 9 to destroy` — both control planes replaced |
| after | `2 to add, 2 to change, 3 to destroy` — VMs updated in place |

`terraform validate` and `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)