### PR TITLE
talos-pve: expose disk_ssd and disk_discard for the primary disk

### DIFF
--- a/modules/proxmox/talos-pve/main.tf
+++ b/modules/proxmox/talos-pve/main.tf
@@ -33,11 +33,15 @@ locals {
         try(inst.description, null),
         format("%s %s", var.default_description_prefix, coalesce(try(inst.name, null), key))
       )
-      proxmox_node         = inst.proxmox_node
-      vm_id                = try(inst.vm_id, null)
-      iso_storage          = coalesce(try(inst.iso_storage, null), var.default_iso_storage)
-      disk_storage         = coalesce(try(inst.disk_storage, null), var.default_disk_storage)
-      disk_interface       = coalesce(try(inst.disk_interface, null), var.default_disk_interface)
+      proxmox_node   = inst.proxmox_node
+      vm_id          = try(inst.vm_id, null)
+      iso_storage    = coalesce(try(inst.iso_storage, null), var.default_iso_storage)
+      disk_storage   = coalesce(try(inst.disk_storage, null), var.default_disk_storage)
+      disk_interface = coalesce(try(inst.disk_interface, null), var.default_disk_interface)
+      # Not coalesce(): it treats `false` as absent, so a per-instance
+      # `disk_ssd = false` would be silently discarded in favour of the default.
+      disk_ssd             = try(inst.disk_ssd, null) != null ? inst.disk_ssd : var.default_disk_ssd
+      disk_discard         = try(inst.disk_discard, null) != null ? inst.disk_discard : var.default_disk_discard
       skip_iso_download    = local.instance_iso_settings[key].skip
       existing_iso_file_id = local.instance_iso_settings[key].iso_file_id
       vm_specs             = try(inst.vm_specs, null) != null ? inst.vm_specs : var.default_vm_specs
@@ -108,6 +112,8 @@ module "proxmox_vm" {
   vm_specs          = each.value.vm_specs
   disk_storage      = each.value.disk_storage
   disk_interface    = each.value.disk_interface
+  disk_ssd          = each.value.disk_ssd
+  disk_discard      = each.value.disk_discard
   iso_download      = each.value.iso_download
   iso_file_id       = each.value.iso_file_id
   network           = each.value.proxmox_network

--- a/modules/proxmox/talos-pve/variables.tf
+++ b/modules/proxmox/talos-pve/variables.tf
@@ -129,6 +129,22 @@ variable "default_disk_interface" {
   default     = "scsi0"
 }
 
+# Defaults mirror the vm module's own so behaviour is unchanged for existing
+# callers. Note they can't be null here: `nullable` defaults to true, so a null
+# would be passed through as null rather than falling back to the vm module's
+# default — silently changing the effective setting for everyone.
+variable "default_disk_ssd" {
+  description = "Whether the primary VM disk is flagged as SSD. Set false when the backing datastore is spinning rust — the flag advertises non-rotational behaviour and TRIM support to the guest. Overridable per instance via `disk_ssd`."
+  type        = bool
+  default     = true
+}
+
+variable "default_disk_discard" {
+  description = "Discard/TRIM mode for the primary VM disk (\"on\" or \"ignore\"). Overridable per instance via `disk_discard`."
+  type        = string
+  default     = "on"
+}
+
 variable "default_iso_storage" {
   description = "Default datastore used for the Talos ISO. Must allow `iso` content."
   type        = string


### PR DESCRIPTION
## Problem

`talos-pve` passes `disk_storage` and `disk_interface` through to the `vm` module, but not `disk_ssd` or `disk_discard`. The primary disk was therefore pinned to the `vm` module's defaults (`ssd = true`, `discard = "on"`) with **no way to override from a consuming stack**.

Passthrough disks were unaffected — they take a per-disk `ssd` via `coalesce(try(disk.value.ssd, null), var.disk_ssd)` — which is why only the primary disk drifted.

Effect on a VM whose primary disk sits on spinning media: it was permanently flagged non-rotational, advertising TRIM support the backing device doesn't have, and every plan carried an unresolvable diff:

```
~ disk {
    ~ ssd = false -> true
  }
```

## Change

Adds `default_disk_ssd` / `default_disk_discard` with per-instance `disk_ssd` / `disk_discard` overrides, following the module's existing `default_*` + per-instance pattern.

```hcl
inputs = {
  default_disk_ssd = false   # primary disk is on spinning rust
}
```

## Two subtleties worth review attention

**Defaults are `true` / `"on"`, not `null`.** `nullable` defaults to `true`, so Terraform only substitutes a variable's default for an explicit `null` when `nullable = false`. Passing `null` here would pass *through* as null and silently change the effective setting for every existing caller. Mirroring the `vm` module's own defaults keeps behaviour identical unless overridden.

**Lookups use an explicit conditional, not `coalesce()`.** `coalesce()` treats `false` as absent, so a legitimate `disk_ssd = false` would be discarded in favour of the default.

## Verification

Against a live cluster with a spinning primary disk (`virtio0`, `local-lvm`) and an NVMe passthrough (`scsi0`):

| Config | Plan |
|---|---|
| unset | `~ ssd = false -> true` still planned — back-compat holds |
| `default_disk_ssd = false` | `No changes. Your infrastructure matches the configuration.` |

Passthrough disk keeps `ssd = true` in both cases. `terraform validate` and `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)