### PR TITLE
makefile: put the version in the release title

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,10 @@
 ver = $(file < VERSION)
 
+# Usage: make release name="Proxmox default disk fix"
+# Produces a release titled "v0.9.1 Proxmox default disk fix".
 release:
+	@[ -n "$(name)" ] || { echo 'name is required, e.g. make release name="Short description"'; exit 1; }
 	git tag $(ver) -s
 	git push --tags
 	git pull
-	gh release create $(ver)
+	gh release create $(ver) --title "$(ver) $(name)" --generate-notes


### PR DESCRIPTION
`gh release create $(ver)` passed no `--title`, so `gh` defaulted the title to the tag name and then prompted interactively. The version only made it into the release name when typed by hand.

Now:

```
make release name="Proxmox default disk fix"
  -> title: "v0.9.1 Proxmox default disk fix"
```

`name` is required (the recipe fails fast with usage text if omitted), and `--generate-notes` keeps the command non-interactive.

Verified with `make -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)